### PR TITLE
Support String arguments in cs_bindgen functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Declare functions in Rust and expose them to C#.
 
 ```rust
 #[cs_bindgen]
-pub fn greet(name: &str) -> String {
+pub fn greet(name: String) -> String {
     format!("Hello, {}!", name)
 }
 ```
@@ -29,8 +29,6 @@ var greeting = Example.Greet("Ferris");
 // Prints "Hello, Ferris!"
 Console.WriteLine(greeting);
 ```
-
-> NOTE: Above example not yet fully supported. Notably, it's not yet possible to pass a string from C# to Rust (though returning one from Rust to C# work fine).
 
 ## Status
 

--- a/cs-bindgen-cli/src/main.rs
+++ b/cs-bindgen-cli/src/main.rs
@@ -84,12 +84,12 @@ fn main() {
                 #dll_name,
                 EntryPoint = "__cs_bindgen_drop_string",
                 CallingConvention = CallingConvention.Cdecl)]
-            private static extern void DropString(RawString raw);
+            private static extern void DropString(RustOwnedString raw);
 
             #( #fn_bindings )*
 
             [StructLayout(LayoutKind.Sequential)]
-            private struct RawString
+            private struct RustOwnedString
             {
                 public IntPtr Ptr;
                 public ulong Length;
@@ -177,7 +177,7 @@ fn quote_bindgen_fn(bindgen_fn: &BindgenFn, dll_name: &str) -> TokenStream {
 
 fn quote_primitive_binding(return_ty: Primitive) -> TokenStream {
     match return_ty {
-        Primitive::String => quote! { RawString },
+        Primitive::String => quote! { RustOwnedString },
         Primitive::Char => quote! { uint },
         Primitive::I8 => quote! { sbyte },
         Primitive::I16 => quote! { short },

--- a/cs-bindgen-cli/src/main.rs
+++ b/cs-bindgen-cli/src/main.rs
@@ -95,6 +95,13 @@ fn main() {
                 public IntPtr Length;
                 public IntPtr Capacity;
             }
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct RawCsString
+            {
+                public IntPtr Ptr;
+                public int Length;
+            }
         }
     }
     .to_string();
@@ -253,14 +260,8 @@ fn quote_wrapper_fn(bindgen_fn: &BindgenFn, raw_binding: &Ident) -> TokenStream 
 
             let result_expr = match prim {
                 Primitive::String => quote! {
-                    string result;
-                    unsafe
-                    {
-                        result = Encoding.UTF8.GetString((byte*)rawResult.Ptr, (int)rawResult.Length);
-                    }
-
+                    string result = Encoding.UTF8.GetString((byte*)rawResult.Ptr, (int)rawResult.Length);
                     DropString(rawResult);
-
                     return result;
                 },
 
@@ -282,9 +283,11 @@ fn quote_wrapper_fn(bindgen_fn: &BindgenFn, raw_binding: &Ident) -> TokenStream 
     quote! {
         public static #cs_return_ty #cs_fn_name(#args)
         {
-            // TODO: Process args so they're ready to pass to the rust fn.
+            unsafe {
+                // TODO: Process args so they're ready to pass to the rust fn.
 
-            #invoke_expr
+                #invoke_expr
+            }
         }
     }
 }

--- a/cs-bindgen-cli/src/main.rs
+++ b/cs-bindgen-cli/src/main.rs
@@ -92,8 +92,8 @@ fn main() {
             private struct RustOwnedString
             {
                 public IntPtr Ptr;
-                public ulong Length;
-                public ulong Capacity;
+                public IntPtr Length;
+                public IntPtr Capacity;
             }
         }
     }

--- a/cs-bindgen-shared/src/primitive.rs
+++ b/cs-bindgen-shared/src/primitive.rs
@@ -1,5 +1,3 @@
-use proc_macro2::TokenStream;
-use quote::*;
 use serde::*;
 use syn::*;
 
@@ -51,43 +49,5 @@ impl Primitive {
         };
 
         Some(prim)
-    }
-
-    /// Generates the code for returning the final result of the function.
-    pub fn generate_return_expr(
-        &self,
-        ret_val: &Ident,
-        args: &mut Vec<TokenStream>,
-    ) -> TokenStream {
-        match self {
-            Primitive::String => {
-                // Generate the out param for the length of the string.
-                let out_param = format_ident!("out_len");
-                args.push(quote! {
-                    #out_param: *mut i32
-                });
-
-                // Generate the code for
-                quote! {
-                    *#out_param = #ret_val
-                        .len()
-                        .try_into()
-                        .expect("String length is too large for `i32`");
-
-                    std::ffi::CString::new(#ret_val)
-                        .expect("Generated string contained a null byte")
-                        .into_raw()
-                }
-            }
-
-            // Cast the bool to a `u8` in order to pass it to C# as a numeric value.
-            Primitive::Bool => quote! {
-                #ret_val as u8
-            },
-
-            // All other primitive types are ABI-compatible with a corresponding C# type, and
-            // require no extra processing to be returned.
-            _ => quote! { #ret_val },
-        }
     }
 }

--- a/cs-bindgen/src/lib.rs
+++ b/cs-bindgen/src/lib.rs
@@ -19,8 +19,8 @@ macro_rules! generate_static_bindings {
     () => {
         /// Drops a `CString` that has been passed to the .NET runtime.
         #[no_mangle]
-        pub unsafe extern "C" fn __cs_bindgen_drop_string(raw: *mut std::os::raw::c_char) {
-            let _ = std::ffi::CString::from_raw(raw);
+        pub unsafe extern "C" fn __cs_bindgen_drop_string(raw: cs_bindgen::RawString) {
+            let _ = raw.into_string();
         }
     };
 }

--- a/cs-bindgen/src/lib.rs
+++ b/cs-bindgen/src/lib.rs
@@ -37,16 +37,16 @@ macro_rules! generate_static_bindings {
 #[repr(C)]
 pub struct RawString {
     pub ptr: *mut u8,
-    pub len: u64,
-    pub capacity: u64,
+    pub len: usize,
+    pub capacity: usize,
 }
 
 impl RawString {
     pub fn from_string(mut string: String) -> Self {
         let raw = Self {
             ptr: string.as_mut_ptr(),
-            len: string.len() as u64,
-            capacity: string.capacity() as u64,
+            len: string.len(),
+            capacity: string.capacity(),
         };
 
         // Ensure that the string isn't de-allocated, effectively transferring ownership of

--- a/integration-tests/TestRunner/GreetTests.cs
+++ b/integration-tests/TestRunner/GreetTests.cs
@@ -27,5 +27,22 @@ namespace TestRunner
             int result = IntegrationTests.ReturnANumber();
             Assert.Equal(7, result);
         }
+
+        [Fact]
+        public void StringArg()
+        {
+            string result = IntegrationTests.StringArg("Test");
+            Assert.Equal("Hello, Test!", result);
+        }
+
+        [Fact]
+        public void StringArgRepeated()
+        {
+            for (int number = 0; number < 1000; number += 1)
+            {
+                string result = IntegrationTests.StringArg("Test");
+                Assert.Equal("Hello, Test!", result);
+            }
+        }
     }
 }

--- a/integration-tests/builder/src/main.rs
+++ b/integration-tests/builder/src/main.rs
@@ -4,7 +4,6 @@ fn main() {
     // Get the environment variables set by cargo so that we can put together the right
     // paths regardless of where in the directory structure this is invoked.
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    dbg!(&manifest_dir);
 
     let wasm_module_path =
         manifest_dir.join("../../target/wasm32-unknown-unknown/debug/integration_tests.wasm");

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -12,7 +12,7 @@ pub fn return_a_number() -> i32 {
     7
 }
 
-// #[cs_bindgen]
-// pub fn string_arg(arg: String) -> String {
-//     format!("Hello, {}!", arg)
-// }
+#[cs_bindgen]
+pub fn string_arg(arg: String) -> String {
+    format!("Hello, {}!", arg)
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -11,3 +11,8 @@ pub fn greet_a_number(num: i32) -> String {
 pub fn return_a_number() -> i32 {
     7
 }
+
+// #[cs_bindgen]
+// pub fn string_arg(arg: String) -> String {
+//     format!("Hello, {}!", arg)
+// }


### PR DESCRIPTION
In addition to adding support for `String` arguments, I've also tweaked how returning strings works. We no longer to inject an extra `out` parameter in order to get the length of the string. Instead, we return a whole struct `RawString` (`RustOwnedString` on the C# side). This simplifies code generation nicely.