### PR TITLE
Fix support of &mut methods

### DIFF
--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -207,8 +207,8 @@ fn quote_method(item: &Method) -> TokenStream {
         });
 
         process_args.extend(quote! {
-            let #receiver_arg_ident = #receiver_arg_ident.lock().expect("Handle mutex was poisoned");
-            let #receiver_arg_ident = &*#receiver_arg_ident;
+            let mut #receiver_arg_ident = #receiver_arg_ident.lock().expect("Handle mutex was poisoned");
+            let #receiver_arg_ident = &mut *#receiver_arg_ident;
         });
 
         arg_names.push(receiver_arg_ident.clone());

--- a/integration-tests/TestRunner/GreetTests.cs
+++ b/integration-tests/TestRunner/GreetTests.cs
@@ -64,5 +64,15 @@ namespace TestRunner
                 info.Dispose();
             }
         }
+
+        public void SetAge()
+        {
+            using (PersonInfo info = new PersonInfo("David", 12))
+            {
+                Assert.Equal(12, info.Age());
+                info.SetAge(22);
+                Assert.Equal(22, info.Age());
+            }
+        }
     }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -38,6 +38,10 @@ impl PersonInfo {
     pub fn age(&self) -> i32 {
         self.age
     }
+
+    pub fn set_age(&mut self, age: i32) {
+        self.age = age;
+    }
 }
 
 #[cs_bindgen]


### PR DESCRIPTION
The implementation of methods added in #12 had a bug where methods taking `&mut self` wouldn't correctly borrow the underlying mutex, resulting in a compiler error. This change fixes that issue and adds regression tests for it.