### PR TITLE
Support returning a named type from an exported function

### DIFF
--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -54,6 +54,57 @@ pub fn quote_wrapper_fn<'a>(
     }
 }
 
+pub fn quote_invoke_args<'a>(
+    args: impl Iterator<Item = (&'a str, &'a Schema)>,
+) -> Punctuated<TokenStream, Comma> {
+    args.map(|(name, schema)| {
+        let ident = format_ident!("{}", name.to_mixed_case());
+        match schema {
+            // Basic numeric types (currently) don't require any processing.
+            Schema::I8
+            | Schema::I16
+            | Schema::I32
+            | Schema::I64
+            | Schema::U8
+            | Schema::U16
+            | Schema::U32
+            | Schema::U64
+            | Schema::F32
+            | Schema::F64 => ident.to_token_stream(),
+
+            Schema::Bool => quote! { (#ident ? 1 : 0) },
+
+            // To pass a string to Rust, we convert it into a `RawCsString` with the fixed pointer.
+            // The code for wrapping the body of the function in a `fixed` block is done below,
+            // since we need to generate the contents of the block first.
+            Schema::String => {
+                let fixed_ident = format_ident!("__fixed_{}", ident);
+                quote! {
+                    new RawCsString(#fixed_ident, #ident.Length)
+                }
+            }
+
+            Schema::Char => todo!("Support converting a C# `char` into a Rust `char`"),
+
+            // TODO: Add support for passing user-defined types out from Rust.
+            Schema::Struct(_)
+            | Schema::UnitStruct(_)
+            | Schema::NewtypeStruct(_)
+            | Schema::TupleStruct(_)
+            | Schema::Enum(_)
+            | Schema::Option(_)
+            | Schema::Seq(_)
+            | Schema::Tuple(_)
+            | Schema::Map { .. } => todo!("Generate argument binding"),
+
+            Schema::I128 | Schema::U128 | Schema::Unit => {
+                unreachable!("Invalid argument types should have already been rejected");
+            }
+        }
+    })
+    .collect::<Punctuated<_, Comma>>()
+}
+
 pub fn quote_wrapper_body<'a>(
     binding_name: &str,
     receiver: Option<TokenStream>,
@@ -61,57 +112,9 @@ pub fn quote_wrapper_body<'a>(
     output: &Schema,
     ret: &Ident,
 ) -> TokenStream {
-    // Build the list of arguments to the wrapper function.
-    let mut invoke_args = args
-        .clone()
-        .map(|(name, schema)| {
-            let ident = format_ident!("{}", name.to_mixed_case());
-            match schema {
-                // Basic numeric types (currently) don't require any processing.
-                Schema::I8
-                | Schema::I16
-                | Schema::I32
-                | Schema::I64
-                | Schema::U8
-                | Schema::U16
-                | Schema::U32
-                | Schema::U64
-                | Schema::F32
-                | Schema::F64 => ident.to_token_stream(),
-
-                Schema::Bool => quote! { (#ident ? 1 : 0) },
-
-                // To pass a string to Rust, we convert it into a `RawCsString` with the fixed pointer.
-                // The code for wrapping the body of the function in a `fixed` block is done below,
-                // since we need to generate the contents of the block first.
-                Schema::String => {
-                    let fixed_ident = format_ident!("__fixed_{}", ident);
-                    quote! {
-                        new RawCsString(#fixed_ident, #ident.Length)
-                    }
-                }
-
-                Schema::Char => todo!("Support converting a C# `char` into a Rust `char`"),
-
-                // TODO: Add support for passing user-defined types out from Rust.
-                Schema::Struct(_)
-                | Schema::UnitStruct(_)
-                | Schema::NewtypeStruct(_)
-                | Schema::TupleStruct(_)
-                | Schema::Enum(_)
-                | Schema::Option(_)
-                | Schema::Seq(_)
-                | Schema::Tuple(_)
-                | Schema::Map { .. } => todo!("Generate argument binding"),
-
-                Schema::I128 | Schema::U128 | Schema::Unit => {
-                    unreachable!("Invalid argument types should have already been rejected");
-                }
-            }
-        })
-        .collect::<Punctuated<_, Comma>>();
-
-    // Insert the receiver at the beginning of the list of arguments, if necessary.
+    // Build the list of arguments to the wrapper function and insert the receiver at
+    // the beginning of the list of arguments if necessary.
+    let mut invoke_args = quote_invoke_args(args.clone());
     if let Some(receiver) = receiver {
         invoke_args.insert(0, receiver);
     }
@@ -162,7 +165,7 @@ pub fn quote_wrapper_body<'a>(
 
         // TODO: Look up the referenced type and process the raw return value based on the
         // type of binding being generated for the type. For now we only support treating
-        // named types as handles, so we don't do any processing with the returned pointer.
+        // named types as handles, so we always pass the handle to the type's constructor.
         Schema::Struct(output) => {
             let ty_ident = format_ident!("{}", &*output.name.name);
             quote! { #ret = new #ty_ident(#invoke); }
@@ -187,7 +190,14 @@ pub fn quote_wrapper_body<'a>(
     // be passed as pointers to Rust (just strings for now). We use `Iterator::fold` to
     // generate a series of nested `fixed` blocks. This is very smart code and won't be
     // hard to maintain at all, I'm sure.
-    args.fold(invoke, |body, (name, schema)| match schema {
+    fold_fixed_blocks(invoke, args)
+}
+
+pub fn fold_fixed_blocks<'a>(
+    base_invoke: TokenStream,
+    args: impl Iterator<Item = (&'a str, &'a Schema)>,
+) -> TokenStream {
+    args.fold(base_invoke, |body, (name, schema)| match schema {
         Schema::String => {
             let arg_ident = format_ident!("{}", name.to_mixed_case());
             let fixed_ident = format_ident!("__fixed_{}", arg_ident);

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -163,7 +163,10 @@ pub fn quote_wrapper_body<'a>(
         // TODO: Look up the referenced type and process the raw return value based on the
         // type of binding being generated for the type. For now we only support treating
         // named types as handles, so we don't do any processing with the returned pointer.
-        Schema::Struct(_) => quote! { #ret = #invoke; },
+        Schema::Struct(output) => {
+            let ty_ident = format_ident!("{}", &*output.name.name);
+            quote! { #ret = new #ty_ident(#invoke); }
+        }
 
         // TODO: Add support for passing user-defined types out from Rust.
         Schema::UnitStruct(_)

--- a/integration-tests/TestRunner/GreetTests.cs
+++ b/integration-tests/TestRunner/GreetTests.cs
@@ -81,5 +81,18 @@ namespace TestRunner
         {
             Assert.Equal(7, PersonInfo.StaticFunction());
         }
+
+        [Fact]
+        public void PersonAddress()
+        {
+            using (PersonInfo info = new PersonInfo("David", 12))
+            {
+                using (Address address = info.Address())
+                {
+                    Assert.Equal(123u, address.StreetNumber());
+                    Assert.Equal("Cool Kids Lane", address.StreetName());
+                }
+            }
+        }
     }
 }

--- a/integration-tests/TestRunner/GreetTests.cs
+++ b/integration-tests/TestRunner/GreetTests.cs
@@ -94,5 +94,21 @@ namespace TestRunner
                 }
             }
         }
+
+        [Fact]
+        public void CreateManyPersonAddresses()
+        {
+            using (PersonInfo info = new PersonInfo("David", 12))
+            {
+                for (var count = 0; count < 1000; count += 1)
+                {
+                    using (Address address = info.Address())
+                    {
+                        Assert.Equal(123u, address.StreetNumber());
+                        Assert.Equal("Cool Kids Lane", address.StreetName());
+                    }
+                }
+            }
+        }
     }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -40,10 +40,6 @@ impl PersonInfo {
         }
     }
 
-    pub fn with_address(name: String, age: i32, address: Address) -> PersonInfo {
-        Self { name, age, address }
-    }
-
     // TODO: Change this to return `&str` once that's supported.
     pub fn name(&self) -> String {
         self.name.clone()

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -40,6 +40,10 @@ impl PersonInfo {
         }
     }
 
+    pub fn with_address(name: String, age: i32, address: Address) -> PersonInfo {
+        Self { name, age, address }
+    }
+
     // TODO: Change this to return `&str` once that's supported.
     pub fn name(&self) -> String {
         self.name.clone()

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -23,13 +23,21 @@ pub fn string_arg(arg: String) -> String {
 pub struct PersonInfo {
     name: String,
     age: i32,
+    address: Address,
 }
 
 #[cs_bindgen]
 impl PersonInfo {
     // TODO: Change the return type back to `Self` once that's supported.
     pub fn new(name: String, age: i32) -> PersonInfo {
-        Self { name, age }
+        Self {
+            name,
+            age,
+            address: Address {
+                street_number: 123,
+                street: "Cool Kids Lane".into(),
+            },
+        }
     }
 
     // TODO: Change this to return `&str` once that's supported.
@@ -47,6 +55,29 @@ impl PersonInfo {
 
     pub fn static_function() -> i32 {
         7
+    }
+
+    pub fn address(&self) -> Address {
+        self.address.clone()
+    }
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct Address {
+    street_number: u32,
+    street: String,
+}
+
+#[cs_bindgen]
+impl Address {
+    pub fn street_number(&self) -> u32 {
+        self.street_number
+    }
+
+    // TODO: Change this to return `&str` once that's supported.
+    pub fn street_name(&self) -> String {
+        self.street.clone()
     }
 }
 


### PR DESCRIPTION
Previously the generated C# bindings only correctly handled returning a named type in the case of a constructor. This PR generalizes support by adding an internal constructor for handle types so that they can be constructed directly from their handle.