### PR TITLE
Fix code generation for functions returning bool

### DIFF
--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -249,7 +249,7 @@ pub fn quote_cs_type(schema: &Schema) -> TokenStream {
         Schema::U64 => quote! { ulong },
         Schema::F32 => quote! { float },
         Schema::F64 => quote! { double },
-        Schema::Bool => quote! { byte },
+        Schema::Bool => quote! { bool },
         Schema::String => quote! { string },
 
         Schema::Char => todo!("Support passing single chars"),

--- a/integration-tests/TestRunner/GreetTests.cs
+++ b/integration-tests/TestRunner/GreetTests.cs
@@ -46,6 +46,13 @@ namespace TestRunner
         }
 
         [Fact]
+        public void BoolReturn()
+        {
+            Assert.True(IntegrationTests.IsSeven(7));
+            Assert.False(IntegrationTests.IsSeven(12));
+        }
+
+        [Fact]
         public void CreatePersonInfo()
         {
             using (PersonInfo info = new PersonInfo("David", 12))
@@ -71,8 +78,11 @@ namespace TestRunner
             using (PersonInfo info = new PersonInfo("David", 12))
             {
                 Assert.Equal(12, info.Age());
+                Assert.True(info.IsMinor());
+
                 info.SetAge(22);
                 Assert.Equal(22, info.Age());
+                Assert.False(info.IsMinor());
             }
         }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -19,6 +19,11 @@ pub fn string_arg(arg: String) -> String {
 }
 
 #[cs_bindgen]
+pub fn is_seven(value: i32) -> bool {
+    value == 7
+}
+
+#[cs_bindgen]
 #[derive(Debug, Clone)]
 pub struct PersonInfo {
     name: String,
@@ -59,6 +64,10 @@ impl PersonInfo {
 
     pub fn address(&self) -> Address {
         self.address.clone()
+    }
+
+    pub fn is_minor(&self) -> bool {
+        self.age < 21
     }
 }
 


### PR DESCRIPTION
The generated C# binding for functions returning `bool` were set to return `byte` instead of `bool`. This PR fixes the generated bindings, and adds regression tests for functions returning `bool`.