### PR TITLE
Initial support for exporting enums

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -1,4 +1,4 @@
-use self::{binding::*, class::*, func::*};
+use self::{binding::*, class::*, enumeration::*, func::*};
 use crate::Opt;
 use cs_bindgen_shared::Export;
 use heck::*;
@@ -7,6 +7,7 @@ use std::ffi::OsStr;
 
 mod binding;
 mod class;
+mod enumeration;
 mod func;
 
 pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, failure::Error> {
@@ -29,7 +30,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         .collect::<Result<_, _>>()?;
 
     let mut fn_bindings = Vec::new();
-    let mut method_bindings = Vec::new();
+    let mut binding_items = Vec::new();
     for export in &exports {
         match export {
             Export::Fn(export) => fn_bindings.push(quote_wrapper_fn(
@@ -39,9 +40,9 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 export.inputs(),
                 &export.output,
             )),
-            Export::Struct(export) => method_bindings.push(quote_struct(export)),
-            Export::Method(export) => method_bindings.push(quote_method_binding(export)),
-            Export::Enum(_export) => {}
+            Export::Struct(export) => binding_items.push(quote_struct(export)),
+            Export::Method(export) => binding_items.push(quote_method_binding(export)),
+            Export::Enum(export) => binding_items.push(quote_enum_binding(export)),
         }
     }
 
@@ -66,7 +67,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             #( #fn_bindings )*
         }
 
-        #( #method_bindings )*
+        #( #binding_items )*
 
         [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct RustOwnedString

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -1,7 +1,8 @@
 use self::{binding::*, class::*, enumeration::*, func::*};
 use crate::Opt;
-use cs_bindgen_shared::Export;
+use cs_bindgen_shared::{schematic::Primitive, Export};
 use heck::*;
+use proc_macro2::TokenStream;
 use quote::*;
 use std::ffi::OsStr;
 
@@ -98,4 +99,29 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
     };
 
     Ok(generated.to_string())
+}
+
+/// Quotes the C# type corresponding to the given Rust primitive.
+///
+/// # Panics
+///
+/// Panics for `I128` and `U128`, since C# does not natively support 128 bit
+/// integers. In order to avoid panicking, all types used in generated bindings
+/// should be validated at the beginning of code generation and an error should be
+/// generated for any unsupported types.
+fn quote_primitive_type(ty: Primitive) -> TokenStream {
+    match ty {
+        Primitive::U8 => quote! { byte },
+        Primitive::U16 => quote! { ushort },
+        Primitive::U32 => quote! { uint },
+        Primitive::U64 => quote! { ulong },
+        Primitive::Usize => quote! { UIntPtr },
+        Primitive::I8 => quote! { sbyte },
+        Primitive::I16 => quote! { short },
+        Primitive::I32 => quote! { int },
+        Primitive::I64 => quote! { long },
+        Primitive::Isize => quote! { IntPtr },
+
+        Primitive::I128 | Primitive::U128 => panic!("128 bit integers not supported"),
+    }
 }

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -41,6 +41,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             )),
             Export::Struct(export) => method_bindings.push(quote_struct(export)),
             Export::Method(export) => method_bindings.push(quote_method_binding(export)),
+            Export::Enum(_export) => {}
         }
     }
 

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -94,12 +94,17 @@ fn quote_binding_args<'a>(
                     ))
                 }
 
-                // TODO: Add support for passing user-defined types out from Rust.
+                // TODO: Actually look up the referenced type to determine what style of binding is
+                // being used and what the repr of the discriminant is. For now we only have support
+                // for simple (C-like) enums without an explicit repr, so the raw value will always
+                // be an `isize`.
+                Schema::Enum(_) => quote! { UIntPtr },
+
+                // TODO: Add support for passing user-defined types to Rust.
                 Schema::Struct(_)
                 | Schema::UnitStruct(_)
                 | Schema::NewtypeStruct(_)
                 | Schema::TupleStruct(_)
-                | Schema::Enum(_)
                 | Schema::Option(_)
                 | Schema::Seq(_)
                 | Schema::Tuple(_)
@@ -143,11 +148,16 @@ fn quote_binding_return_type(schema: &Schema) -> Result<TokenStream, failure::Er
         // treat them as a handle, so we hard code that case here.
         Schema::Struct(_) => quote! { void* },
 
+        // TODO: Actually look up the referenced type to determine what style of binding is
+        // being used and what the repr of the discriminant is. For now we only have support
+        // for simple (C-like) enums without an explicit repr, so the raw value will always
+        // be an `isize`.
+        Schema::Enum(_) => quote! { UIntPtr },
+
         // TODO: Add support for passing user-defined types out from Rust.
         Schema::UnitStruct(_)
         | Schema::NewtypeStruct(_)
         | Schema::TupleStruct(_)
-        | Schema::Enum(_)
         | Schema::Option(_)
         | Schema::Seq(_)
         | Schema::Tuple(_)

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -44,7 +44,11 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str) -> Result<TokenStream,
             })
         }
 
+        // TODO: Only generate a drop fn if we're binding the struct as a handle type.
         Export::Struct(item) => Ok(class::quote_drop_fn(&item.name, dll_name)),
+
+        // TODO: Generate a drop function if we're binding the enum as a handle type.
+        Export::Enum(_) => Ok(Default::default()),
     }
 }
 

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -98,7 +98,7 @@ fn quote_binding_args<'a>(
                 // being used and what the repr of the discriminant is. For now we only have support
                 // for simple (C-like) enums without an explicit repr, so the raw value will always
                 // be an `isize`.
-                Schema::Enum(_) => quote! { UIntPtr },
+                Schema::Enum(_) => quote! { IntPtr },
 
                 // TODO: Add support for passing user-defined types to Rust.
                 Schema::Struct(_)
@@ -152,7 +152,7 @@ fn quote_binding_return_type(schema: &Schema) -> Result<TokenStream, failure::Er
         // being used and what the repr of the discriminant is. For now we only have support
         // for simple (C-like) enums without an explicit repr, so the raw value will always
         // be an `isize`.
-        Schema::Enum(_) => quote! { UIntPtr },
+        Schema::Enum(_) => quote! { IntPtr },
 
         // TODO: Add support for passing user-defined types out from Rust.
         Schema::UnitStruct(_)

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -23,6 +23,8 @@ pub fn quote_struct(export: &Struct) -> TokenStream {
             let drop_fn = format_ident!("__cs_bindgen_drop__{}", &*export.name);
             quote_handle_type(&ident, &drop_fn)
         }
+
+        BindingStyle::Value => unimplemented!("Pass struct by value"),
     }
 }
 

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -1,0 +1,63 @@
+use cs_bindgen_shared::{schematic, schematic::Variant, Enum};
+use proc_macro2::TokenStream;
+use quote::*;
+use syn::LitInt;
+
+pub fn quote_enum_binding(item: &Enum) -> TokenStream {
+    let schema = item
+        .schema
+        .as_enum()
+        .expect("Enum item's schema does not describe an enum");
+
+    // Determine if we're dealing with a simple (C-like) enum or one with fields.
+    //
+    // TODO: Move this logic into a helper method on `schematic::Enum`.
+    let mut has_fields = false;
+    for variant in &schema.variants {
+        match variant {
+            Variant::Unit { .. } => {}
+
+            _ => {
+                has_fields = true;
+                break;
+            }
+        }
+    }
+
+    if has_fields {
+        todo!("Generate bindings for a complex enum")
+    } else {
+        quote_simple_enum_binding(item, schema)
+    }
+}
+
+fn quote_simple_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStream {
+    let ident = format_ident!("{}", &*item.name);
+    let variants = schema.variants.iter().map(|variant| {
+        let (name, discriminant) = match variant {
+            Variant::Unit { name, discriminant } => (name, discriminant),
+
+            _ => panic!("Simple enum can only have unit variants"),
+        };
+
+        let variant_ident = format_ident!("{}", &**name);
+        let discriminant = match discriminant {
+            Some(discriminant) => {
+                let lit = syn::parse_str::<LitInt>(&discriminant.to_string())
+                    .expect("Failed to parse discriminant as a `LitInt`");
+                quote! { = #lit }
+            }
+            None => TokenStream::new(),
+        };
+
+        quote! {
+            #variant_ident #discriminant
+        }
+    });
+
+    quote! {
+        public enum #ident {
+            #( #variants ),*
+        }
+    }
+}

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -1,7 +1,6 @@
 use cs_bindgen_shared::{schematic, schematic::Variant, Enum};
 use proc_macro2::TokenStream;
 use quote::*;
-use syn::LitInt;
 
 pub fn quote_enum_binding(item: &Enum) -> TokenStream {
     let schema = item
@@ -43,7 +42,7 @@ fn quote_simple_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStre
         let variant_ident = format_ident!("{}", &**name);
         let discriminant = match discriminant {
             Some(discriminant) => {
-                let lit = syn::parse_str::<LitInt>(&discriminant.to_string())
+                let lit = syn::parse_str::<syn::Expr>(&discriminant.to_string())
                     .expect("Failed to parse discriminant as a `LitInt`");
                 quote! { = #lit }
             }

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -1,3 +1,4 @@
+use crate::generate::quote_primitive_type;
 use cs_bindgen_shared::*;
 use heck::*;
 use proc_macro2::TokenStream;
@@ -86,12 +87,22 @@ pub fn quote_invoke_args<'a>(
 
             Schema::Char => todo!("Support converting a C# `char` into a Rust `char`"),
 
+            // TODO: Actually look up the referenced type to determine what style of binding is
+            // being used. For now we only have support for simple (C-like) enums, so we simply
+            // cast the value to the appropriate integer type based on the enum repr.
+            Schema::Enum(schema) => {
+                let repr = schema
+                    .repr
+                    .map(quote_primitive_type)
+                    .unwrap_or_else(|| quote! { UIntPtr });
+                quote! { (#repr)#ident }
+            }
+
             // TODO: Add support for passing user-defined types out from Rust.
             Schema::Struct(_)
             | Schema::UnitStruct(_)
             | Schema::NewtypeStruct(_)
             | Schema::TupleStruct(_)
-            | Schema::Enum(_)
             | Schema::Option(_)
             | Schema::Seq(_)
             | Schema::Tuple(_)
@@ -171,15 +182,22 @@ pub fn quote_wrapper_body<'a>(
             quote! { #ret = new #ty_ident(#invoke); }
         }
 
+        // TODO: Look up the referenced type and process the raw return value based on the
+        // type of binding being generated for the type. For now we only support treating
+        // named types as handles, so we always pass the handle to the type's constructor.
+        Schema::Enum(output) => {
+            let ty_ident = format_ident!("{}", &*output.name.name);
+            quote! { #ret = (#ty_ident)#invoke; }
+        }
+
         // TODO: Add support for passing user-defined types out from Rust.
         Schema::UnitStruct(_)
         | Schema::NewtypeStruct(_)
         | Schema::TupleStruct(_)
-        | Schema::Enum(_)
         | Schema::Option(_)
         | Schema::Seq(_)
         | Schema::Tuple(_)
-        | Schema::Map { .. } => todo!("Generate argument binding"),
+        | Schema::Map { .. } => todo!("Generate return value conversion in wrapper function"),
 
         Schema::I128 | Schema::U128 => {
             unreachable!("Invalid argument types should have already been rejected");
@@ -254,13 +272,16 @@ pub fn quote_cs_type(schema: &Schema) -> TokenStream {
 
         Schema::Char => todo!("Support passing single chars"),
 
-        Schema::Struct(struct_) => format_ident!("{}", &*struct_.name.name).to_token_stream(),
+        // TODO: When referencing generated types in function signatures, take custom
+        // namespacing into account. Custom namespaces aren't currently supported, but
+        // once they are it won't be sufficient to directly quote the name of the type.
+        Schema::Struct(schema) => format_ident!("{}", &*schema.name.name).to_token_stream(),
+        Schema::Enum(schema) => format_ident!("{}", &*schema.name.name).to_token_stream(),
 
         // TODO: Add support for passing user-defined types out from Rust.
         Schema::UnitStruct(_)
         | Schema::NewtypeStruct(_)
         | Schema::TupleStruct(_)
-        | Schema::Enum(_)
         | Schema::Option(_)
         | Schema::Seq(_)
         | Schema::Tuple(_)

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -94,7 +94,7 @@ pub fn quote_invoke_args<'a>(
                 let repr = schema
                     .repr
                     .map(quote_primitive_type)
-                    .unwrap_or_else(|| quote! { UIntPtr });
+                    .unwrap_or_else(|| quote! { IntPtr });
                 quote! { (#repr)#ident }
             }
 

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -1,0 +1,74 @@
+use crate::func::*;
+use proc_macro2::TokenStream;
+use quote::*;
+use syn::*;
+
+pub fn quote_enum_item(item: ItemEnum) -> syn::Result<TokenStream> {
+    reject_generics(
+        &item.generics,
+        "Generic enums not supported with `#[cs_bindgen]`",
+    )?;
+
+    // Check the variants to determine if we're dealing with a C-style enum or one that
+    // carries additional data.
+    let mut has_fields = false;
+    for variant in &item.variants {
+        match variant.fields {
+            Fields::Unit => {}
+            _ => {
+                has_fields = true;
+                break;
+            }
+        }
+    }
+
+    if has_fields {
+        quote_complex_enum(item)
+    } else {
+        quote_simple_enum(item)
+    }
+}
+
+fn quote_simple_enum(item: ItemEnum) -> syn::Result<TokenStream> {
+    let ident = item.ident;
+
+    Ok(quote! {
+        // Implement `Describe` for the enum.
+        impl cs_bindgen::shared::schematic::Describe for #ident {
+            fn describe<E>(describer: E) -> Result<E::Ok, E::Error>
+            where
+                E: cs_bindgen::shared::schematic::Describer,
+            {
+                todo!("Describe the enum")
+            }
+        }
+
+        // Implement `FromAbi` and `IntoAbi` for the enum.
+
+        impl cs_bindgen::abi::IntoAbi for #ident {
+            type Abi = u64;
+
+            fn into_abi(self) -> Self::Abi {
+                self as u64
+            }
+        }
+
+        impl cs_bindgen::abi::FromAbi for #ident {
+            type Abi = u64;
+
+            unsafe fn from_abi(abi: Self::Abi) -> Self {
+                match abi {
+                    $( #from_abi_patterns )*
+
+                    _ => panic!("Unknown variant {} for enum {}", abi, stringify!(#ident)),
+                }
+            }
+        }
+
+        // TODO: Generate the descriptor function.
+    })
+}
+
+fn quote_complex_enum(_item: ItemEnum) -> syn::Result<TokenStream> {
+    todo!("Generate bindings for data-carrying enum");
+}

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -32,6 +32,61 @@ pub fn quote_enum_item(item: ItemEnum) -> syn::Result<TokenStream> {
 fn quote_simple_enum(item: ItemEnum) -> syn::Result<TokenStream> {
     let ident = item.ident;
 
+    // TODO: Check for a `#[repr(...)]` attribute and handle alternate types for the
+    // discriminant.
+    let discriminant_ty = quote! { isize };
+
+    // Generate constants for each discriminant of the enum. This is to handle arbitrary expressions for discriminant values.
+    let mut prev_discriminant = None;
+    let discriminant_consts = item.variants.iter().map(|variant| {
+        let const_ident = format_ident!(
+            "__cs_bindgen_generated__{}__{}__DISCRIMINANT",
+            ident,
+            &variant.ident
+        );
+
+        // Generate the expression for the variant's discriminant:
+        //
+        // * If the variant has an explicit discriminant, reuse that expression in the constant.
+        // * Otherwise, the discriminant is the previous discriminant plus 1.
+        // * Otherwise the default is 0 (in the case where there was no previous discriminant).
+        //
+        // This matches the default behavior for how discriminant values are determined:
+        // https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-field-less-enumerations
+        let expr = variant
+            .discriminant
+            .as_ref()
+            .map(|(_, expr)| expr.to_token_stream())
+            .or_else(|| {
+                prev_discriminant.take().map(|prev_discriminant| {
+                    quote! {
+                        #prev_discriminant + 1
+                    }
+                })
+            })
+            .unwrap_or(quote! { 0 });
+
+        prev_discriminant = Some(const_ident.clone());
+
+        quote! {
+            const #const_ident: #discriminant_ty = #expr;
+        }
+    });
+
+    // Generate the match arms for the `FromAbi` impl.
+    let from_abi_patterns = item.variants.iter().map(|variant| {
+        let const_ident = format_ident!(
+            "__cs_bindgen_generated__{}__{}__DISCRIMINANT",
+            ident,
+            &variant.ident
+        );
+        let variant_ident = &variant.ident;
+
+        quote! {
+            #const_ident => #ident::#variant_ident
+        }
+    });
+
     Ok(quote! {
         // Implement `Describe` for the enum.
         impl cs_bindgen::shared::schematic::Describe for #ident {
@@ -46,19 +101,22 @@ fn quote_simple_enum(item: ItemEnum) -> syn::Result<TokenStream> {
         // Implement `FromAbi` and `IntoAbi` for the enum.
 
         impl cs_bindgen::abi::IntoAbi for #ident {
-            type Abi = u64;
+            type Abi = #discriminant_ty;
 
             fn into_abi(self) -> Self::Abi {
-                self as u64
+                self as #discriminant_ty
             }
         }
 
         impl cs_bindgen::abi::FromAbi for #ident {
-            type Abi = u64;
+            type Abi = #discriminant_ty;
 
+            #[allow(bad_style)]
             unsafe fn from_abi(abi: Self::Abi) -> Self {
+                #( #discriminant_consts )*
+
                 match abi {
-                    $( #from_abi_patterns )*
+                    #( #from_abi_patterns, )*
 
                     _ => panic!("Unknown variant {} for enum {}", abi, stringify!(#ident)),
                 }

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -36,11 +36,16 @@ fn quote_simple_enum(item: ItemEnum) -> syn::Result<TokenStream> {
 
     let describe_variants = item.variants.iter().map(|variant| {
         let variant_name = variant.ident.to_string();
+        let discriminant = match &variant.discriminant {
+            Some((_, expr)) => quote! { Some((#expr).into()) },
+            None => quote! { None },
+        };
+
         quote! {
             cs_bindgen::shared::schematic::DescribeEnum::describe_unit_variant(
                 &mut describer,
                 #variant_name,
-                None,
+                #discriminant,
             )?;
         }
     });

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -34,6 +34,17 @@ fn quote_simple_enum(item: ItemEnum) -> syn::Result<TokenStream> {
     let name = ident.to_string();
     let describe_ident = format_describe_ident!(ident);
 
+    let describe_variants = item.variants.iter().map(|variant| {
+        let variant_name = variant.ident.to_string();
+        quote! {
+            cs_bindgen::shared::schematic::DescribeEnum::describe_unit_variant(
+                &mut describer,
+                #variant_name,
+                None,
+            )?;
+        }
+    });
+
     // TODO: Check for a `#[repr(...)]` attribute and handle alternate types for the
     // discriminant.
     let discriminant_ty = quote! { isize };
@@ -96,7 +107,11 @@ fn quote_simple_enum(item: ItemEnum) -> syn::Result<TokenStream> {
             where
                 E: cs_bindgen::shared::schematic::Describer,
             {
-                todo!("Describe the enum")
+                let mut describer = describer.describe_enum(
+                    cs_bindgen::shared::schematic::type_name!(#ident),
+                )?;
+                #( #describe_variants )*
+                cs_bindgen::shared::schematic::DescribeEnum::end(describer)
             }
         }
 

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "bae25c5" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "63438fe" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "e0b0751" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "bae25c5" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "8342308" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "e0b0751" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -17,6 +17,7 @@ pub enum Export {
     Fn(Func),
     Method(Method),
     Struct(Struct),
+    Enum(Enum),
 }
 
 /// A free function exported from the Rust lib.
@@ -67,6 +68,13 @@ pub struct Struct {
     pub schema: Schema,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Enum {
+    pub name: Cow<'static, str>,
+    pub binding_style: BindingStyle,
+    pub schema: Schema,
+}
+
 #[derive(Debug, Clone, From, Serialize, Deserialize)]
 pub struct Method {
     pub name: Cow<'static, str>,
@@ -95,4 +103,7 @@ pub enum ReceiverStyle {
 pub enum BindingStyle {
     /// The type is exported as a class wrapping an opaque handle.
     Handle,
+
+    /// Values of the type are marshalled directly into C# values.
+    Value,
 }

--- a/cs-bindgen/Cargo.toml
+++ b/cs-bindgen/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2018"
 [dependencies]
 cs-bindgen-macro = { version = "0.1", path = "../cs-bindgen-macro" }
 cs-bindgen-shared = { version = "0.1", path = "../cs-bindgen-shared" }
+strum = "0.17.1"
+
+[dev-dependencies]
+strum = { version = "0.17.1", features = ["derive"] }

--- a/cs-bindgen/tests/simple_enum_derive.rs
+++ b/cs-bindgen/tests/simple_enum_derive.rs
@@ -40,7 +40,7 @@ fn simple_enum_explicit_discriminants() {
 
     #[cs_bindgen]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
-    pub enum Simple {
+    pub enum ExplicitDiscrim {
         Foo,
         Bar,
         Baz = 5,
@@ -57,9 +57,9 @@ fn simple_enum_explicit_discriminants() {
         NegativePlusTwo,
     }
 
-    for variant in Simple::iter() {
+    for variant in ExplicitDiscrim::iter() {
         let abi = variant.into_abi();
-        let result = unsafe { Simple::from_abi(abi) };
+        let result = unsafe { ExplicitDiscrim::from_abi(abi) };
         assert_eq!(variant, result);
     }
 }
@@ -68,15 +68,15 @@ fn simple_enum_explicit_discriminants() {
 fn simple_enum_explicit_first_discriminant() {
     #[cs_bindgen]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
-    enum Simple {
+    enum FirstDiscriminant {
         Zero = 123,
         One,
         Two,
     }
 
-    for variant in Simple::iter() {
+    for variant in FirstDiscriminant::iter() {
         let abi = variant.into_abi();
-        let result = unsafe { Simple::from_abi(abi) };
+        let result = unsafe { FirstDiscriminant::from_abi(abi) };
         assert_eq!(variant, result);
     }
 }

--- a/cs-bindgen/tests/simple_enum_derive.rs
+++ b/cs-bindgen/tests/simple_enum_derive.rs
@@ -1,0 +1,82 @@
+//! Tests for verifying that `#[cs_bindgen]` generates the correct bindings for
+//! simple enums (i.e. enums that don't carry extra data).
+//!
+//! These tests primarily verify that the generated `FromAbi` and `IntoAbi` impls
+//! agree on the discriminant value for each variant of an enum. This is especially
+//! important for simple enums since the generated code needs to correctly handle
+//! custom discriminant values, which may be arbitrary expressions (including
+//! references to constants).
+//!
+//! In order to verify that the implementations are in sync we do a round-trip
+//! with each variant, i.e. pass the result of `IntoAbi::into_abi` back through
+//! `FromAbi::from_abi` and then verify that the result matches the original.
+
+use cs_bindgen::{
+    abi::{FromAbi, IntoAbi},
+    prelude::*,
+};
+use strum::{EnumIter, IntoEnumIterator};
+
+#[test]
+fn simple_enum_round_trip() {
+    #[cs_bindgen]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
+    enum Simple {
+        Zero,
+        One,
+        Two,
+    }
+
+    for variant in Simple::iter() {
+        let abi = variant.into_abi();
+        let result = unsafe { Simple::from_abi(abi) };
+        assert_eq!(variant, result);
+    }
+}
+
+#[test]
+fn simple_enum_explicit_discriminants() {
+    const DISCRIMINANT: isize = 45;
+
+    #[cs_bindgen]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
+    pub enum Simple {
+        Foo,
+        Bar,
+        Baz = 5,
+        Baa,
+        Bab,
+        Quux = 1 + 2 + 3 + 4,
+        Cool,
+        Wool,
+        SomeDiscriminant = DISCRIMINANT,
+        AnotherOne,
+        YetAnotherOne,
+        Negative = -5,
+        NegativePlusOne,
+        NegativePlusTwo,
+    }
+
+    for variant in Simple::iter() {
+        let abi = variant.into_abi();
+        let result = unsafe { Simple::from_abi(abi) };
+        assert_eq!(variant, result);
+    }
+}
+
+#[test]
+fn simple_enum_explicit_first_discriminant() {
+    #[cs_bindgen]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
+    enum Simple {
+        Zero = 123,
+        One,
+        Two,
+    }
+
+    for variant in Simple::iter() {
+        let abi = variant.into_abi();
+        let result = unsafe { Simple::from_abi(abi) };
+        assert_eq!(variant, result);
+    }
+}

--- a/integration-tests/TestRunner/EnumTests.cs
+++ b/integration-tests/TestRunner/EnumTests.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace TestRunner
+{
+    public class EnumTests
+    {
+        [Fact]
+        public void SimpleEnumRoundTrip()
+        {
+            foreach (var variant in Enum.GetValues(typeof(SimpleCEnum)).Cast<SimpleCEnum>())
+            {
+                SimpleCEnum result = IntegrationTests.RoundTripSimpleCEnum(variant);
+                Assert.Equal(variant, result);
+            }
+        }
+    }
+}

--- a/integration-tests/TestRunner/EnumTests.cs
+++ b/integration-tests/TestRunner/EnumTests.cs
@@ -15,5 +15,16 @@ namespace TestRunner
                 Assert.Equal(variant, result);
             }
         }
+
+        [Fact]
+        public void DiscriminantEnumRoundTrip()
+        {
+
+            foreach (var variant in Enum.GetValues(typeof(EnumWithDiscriminants)).Cast<EnumWithDiscriminants>())
+            {
+                EnumWithDiscriminants result = IntegrationTests.RoundtripSimpleEnumWithDiscriminants(variant);
+                Assert.Equal(variant, result);
+            }
+        }
     }
 }

--- a/integration-tests/TestRunner/EnumTests.cs
+++ b/integration-tests/TestRunner/EnumTests.cs
@@ -11,7 +11,7 @@ namespace TestRunner
         {
             foreach (var variant in Enum.GetValues(typeof(SimpleCEnum)).Cast<SimpleCEnum>())
             {
-                SimpleCEnum result = IntegrationTests.RoundTripSimpleCEnum(variant);
+                SimpleCEnum result = IntegrationTests.RoundtripSimpleEnum(variant);
                 Assert.Equal(variant, result);
             }
         }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -108,7 +108,7 @@ pub fn roundtrip_simple_enum(val: SimpleCEnum) -> SimpleCEnum {
 }
 
 #[cs_bindgen]
-pub enum CEnumWithDiscriminants {
+pub enum EnumWithDiscriminants {
     Hello,
     There = 5,
     How,
@@ -118,8 +118,8 @@ pub enum CEnumWithDiscriminants {
 
 #[cs_bindgen]
 pub fn roundtrip_simple_enum_with_discriminants(
-    val: CEnumWithDiscriminants,
-) -> CEnumWithDiscriminants {
+    val: EnumWithDiscriminants,
+) -> EnumWithDiscriminants {
     val
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -94,3 +94,18 @@ impl Address {
 pub fn void_return(test: i32) {
     println!("{}", test);
 }
+
+#[cs_bindgen]
+pub enum SimpleEnum {
+    Foo,
+    Bar,
+    Baz = 12,
+    Quux,
+}
+
+#[cs_bindgen]
+pub enum DataEnum {
+    Foo,
+    Bar(String),
+    Baz { name: String, value: i32 },
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -95,15 +95,26 @@ pub fn void_return(test: i32) {
     println!("{}", test);
 }
 
+const DISCRIMINANT: isize = 45;
+
+// TODO: Write a test that checks each of the variants and confirms that the
+// `FromAbi` and `IntoAbi` impls agree on the discriminant values.
 #[cs_bindgen]
 pub enum SimpleEnum {
     Foo,
     Bar,
-    Baz = 12,
-    Quux,
+    Baz = 5,
+    Baa,
+    Bab,
+    Quux = 1 + 2 + 3 + 4,
+    Cool,
+    Wool,
+    SomeDiscriminant = DISCRIMINANT,
+    AnotherOne,
+    YetAnotherOne,
 }
 
-#[cs_bindgen]
+// #[cs_bindgen]
 pub enum DataEnum {
     Foo,
     Bar(String),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -96,10 +96,19 @@ pub fn void_return(test: i32) {
 }
 
 #[cs_bindgen]
-pub enum SimpleEnum {
+pub enum SimpleCEnum {
     Foo,
     Bar,
     Baz,
+}
+
+#[cs_bindgen]
+pub enum CEnumWithDiscriminants {
+    Hello,
+    There = 5,
+    How,
+    Are,
+    You = -12,
 }
 
 // #[cs_bindgen]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -103,12 +103,24 @@ pub enum SimpleCEnum {
 }
 
 #[cs_bindgen]
+pub fn roundtrip_simple_enum(val: SimpleCEnum) -> SimpleCEnum {
+    val
+}
+
+#[cs_bindgen]
 pub enum CEnumWithDiscriminants {
     Hello,
     There = 5,
     How,
     Are,
     You = -12,
+}
+
+#[cs_bindgen]
+pub fn roundtrip_simple_enum_with_discriminants(
+    val: CEnumWithDiscriminants,
+) -> CEnumWithDiscriminants {
+    val
 }
 
 // #[cs_bindgen]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -95,23 +95,11 @@ pub fn void_return(test: i32) {
     println!("{}", test);
 }
 
-const DISCRIMINANT: isize = 45;
-
-// TODO: Write a test that checks each of the variants and confirms that the
-// `FromAbi` and `IntoAbi` impls agree on the discriminant values.
 #[cs_bindgen]
 pub enum SimpleEnum {
     Foo,
     Bar,
-    Baz = 5,
-    Baa,
-    Bab,
-    Quux = 1 + 2 + 3 + 4,
-    Cool,
-    Wool,
-    SomeDiscriminant = DISCRIMINANT,
-    AnotherOne,
-    YetAnotherOne,
+    Baz,
 }
 
 // #[cs_bindgen]


### PR DESCRIPTION
Support exporting simple (C-like) enums to C#. Only the default repr is supported for now, though most of the pieces needed for supporting it are in place. Support for data-carrying enums will be implemented separately, since it requires handling more complex, nested types than what we currently can support.