### PR TITLE
Fully implement Derive for enums

### DIFF
--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -131,7 +131,7 @@ fn quote_simple_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
 }
 
 fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
-    let ident = &item.ident;
+    // let ident = &item.ident;
     // let name = ident.to_string();
     // let describe_ident = format_describe_ident!(ident);
 

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -132,8 +132,8 @@ fn quote_simple_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
 
 fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
     let ident = &item.ident;
-    let name = ident.to_string();
-    let describe_ident = format_describe_ident!(ident);
+    // let name = ident.to_string();
+    // let describe_ident = format_describe_ident!(ident);
 
     Ok(quote! {
         // TODO: Generate the `From/IntoAbi` impls for the enum.

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -123,7 +123,7 @@ pub fn roundtrip_simple_enum_with_discriminants(
     val
 }
 
-// #[cs_bindgen]
+#[cs_bindgen]
 pub enum DataEnum {
     Foo,
     Bar(String),


### PR DESCRIPTION
This PR adds support for adding `#[cs_bindgen]` to data-carrying enums, though for now it only generates the `Describe` impl for the enum.