### PR TITLE
Generate Rust bindings for complex enums

### DIFF
--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -9,22 +9,9 @@ pub fn quote_enum_binding(item: &Enum) -> TokenStream {
         .expect("Enum item's schema does not describe an enum");
 
     // Determine if we're dealing with a simple (C-like) enum or one with fields.
-    //
-    // TODO: Move this logic into a helper method on `schematic::Enum`.
-    let mut has_fields = false;
-    for variant in &schema.variants {
-        match variant {
-            Variant::Unit { .. } => {}
-
-            _ => {
-                has_fields = true;
-                break;
-            }
-        }
-    }
-
-    if has_fields {
-        todo!("Generate bindings for a complex enum")
+    if schema.has_data() {
+        // TODO: Generate bindings for enums with data.
+        quote! {}
     } else {
         quote_simple_enum_binding(item, schema)
     }

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -165,18 +165,18 @@ fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
         // Implement `From/IntoAbi` conversions for the type and references to the type.
 
         impl cs_bindgen::abi::IntoAbi for #ident {
-            type Abi = std::boxed::Box<Self>;
+            type Abi = *mut Self;
 
             fn into_abi(self) -> Self::Abi {
-                std::boxed::Box::new(self)
+                std::boxed::Box::into_raw(std::boxed::Box::new(self))
             }
         }
 
         impl cs_bindgen::abi::FromAbi for #ident {
-            type Abi = std::boxed::Box<Self>;
+            type Abi = *mut Self;
 
             unsafe fn from_abi(abi: Self::Abi) -> Self {
-                *abi
+                *std::boxed::Box::from_raw(abi)
             }
         }
 
@@ -197,18 +197,18 @@ fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
         }
 
         impl<'a> cs_bindgen::abi::IntoAbi for &'a mut #ident {
-            type Abi = Self;
+            type Abi = *mut #ident;
 
             fn into_abi(self) -> Self::Abi {
-                self
+                self as *mut _
             }
         }
 
         impl<'a> cs_bindgen::abi::FromAbi for &'a mut #ident {
-            type Abi = Self;
+            type Abi = *mut #ident;
 
             unsafe fn from_abi(abi: Self::Abi) -> Self {
-                abi
+                &mut *abi
             }
         }
 

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "8aa3ebe" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "86de159" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen/src/abi.rs
+++ b/cs-bindgen/src/abi.rs
@@ -359,6 +359,13 @@ impl<D, V> RawEnum<D, V> {
             value: MaybeUninit::new(value),
         }
     }
+
+    pub const fn simple(discriminant: D) -> Self {
+        Self {
+            discriminant,
+            value: MaybeUninit::uninit(),
+        }
+    }
 }
 
 unsafe impl<D: AbiPrimitive, V: AbiPrimitive> AbiPrimitive for RawEnum<D, V> {}

--- a/cs-bindgen/src/abi.rs
+++ b/cs-bindgen/src/abi.rs
@@ -360,7 +360,7 @@ impl<D, V> RawEnum<D, V> {
         }
     }
 
-    pub const fn simple(discriminant: D) -> Self {
+    pub const fn unit(discriminant: D) -> Self {
         Self {
             discriminant,
             value: MaybeUninit::uninit(),

--- a/cs-bindgen/src/abi.rs
+++ b/cs-bindgen/src/abi.rs
@@ -315,3 +315,26 @@ impl<'a> From<&'a str> for RawSlice<u8> {
         }
     }
 }
+
+/// Deconstructed representation of an enum, compatible with FFI.
+///
+/// The raw representation of an enum is an explicit discriminant value paired with
+/// a union of all the fields. When converting back from the raw representation, use
+/// the value of the discriminant to determine which union field is valid.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RawEnum<D, V> {
+    pub discriminant: D,
+    pub value: V,
+}
+
+impl<D, V> RawEnum<D, V> {
+    pub const fn new(discriminant: D, value: V) -> Self {
+        Self {
+            discriminant,
+            value,
+        }
+    }
+}
+
+unsafe impl<D: AbiPrimitive, V: AbiPrimitive> AbiPrimitive for RawEnum<D, V> {}

--- a/cs-bindgen/tests/manual_derive.rs
+++ b/cs-bindgen/tests/manual_derive.rs
@@ -61,18 +61,18 @@ impl cs_bindgen::shared::schematic::Describe for ExampleStruct {
 }
 
 impl cs_bindgen::abi::IntoAbi for ExampleStruct {
-    type Abi = std::boxed::Box<Self>;
+    type Abi = *mut Self;
 
     fn into_abi(self) -> Self::Abi {
-        std::boxed::Box::new(self)
+        std::boxed::Box::into_raw(std::boxed::Box::new(self))
     }
 }
 
 impl cs_bindgen::abi::FromAbi for ExampleStruct {
-    type Abi = std::boxed::Box<Self>;
+    type Abi = *mut Self;
 
     unsafe fn from_abi(abi: Self::Abi) -> Self {
-        *abi
+        *std::boxed::Box::from_raw(abi)
     }
 }
 

--- a/cs-bindgen/tests/manual_derive.rs
+++ b/cs-bindgen/tests/manual_derive.rs
@@ -1,12 +1,16 @@
 //! Example of what the code generated from `#[cs_bindgen]` should look like. Used
 //! to verify that the generated code ABI is valid and will compile, and is useful
 //! for understanding how the code generation works.
-//!
-//! For an exported function, we generate two items:
-//!
-//! * The binding function, which is exported as `extern "C"` and handles the
-//!   boilerplate work of converting two and from ABI-compatible types.
-//! * The describe function, which
+
+use cs_bindgen::{abi::*, shared::*};
+use schematic::*;
+use std::mem::ManuallyDrop;
+
+// For an exported function, we generate two items:
+//
+// * The binding function, which is exported as `extern "C"` and handles the
+//   boilerplate work of converting two and from ABI-compatible types.
+// * The describe function, which
 
 pub fn example_fn(first: u32, second: String) -> String {
     format!("first: {}, second: {}", first, second)
@@ -14,18 +18,16 @@ pub fn example_fn(first: u32, second: String) -> String {
 
 #[no_mangle]
 pub unsafe extern "C" fn __cs_bindgen_generated__example_fn(
-    first: <u32 as cs_bindgen::abi::FromAbi>::Abi,
-    second: <String as cs_bindgen::abi::FromAbi>::Abi,
-) -> <String as cs_bindgen::abi::IntoAbi>::Abi {
-    let first = cs_bindgen::abi::FromAbi::from_abi(first);
-    let second = cs_bindgen::abi::FromAbi::from_abi(second);
-    cs_bindgen::abi::IntoAbi::into_abi(example_fn(first, second))
+    first: <u32 as FromAbi>::Abi,
+    second: <String as FromAbi>::Abi,
+) -> <String as IntoAbi>::Abi {
+    let first = FromAbi::from_abi(first);
+    let second = FromAbi::from_abi(second);
+    example_fn(first, second).into_abi()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn __cs_bindgen_describe__example_fn() -> Box<cs_bindgen::abi::RawVec<u8>> {
-    use cs_bindgen::shared::{schematic::describe, Func};
-
+pub unsafe extern "C" fn __cs_bindgen_describe__example_fn() -> Box<RawVec<u8>> {
     let export = Func {
         name: "example_fn".into(),
         binding: "__cs_bindgen_generated__example_fn".into(),
@@ -42,25 +44,29 @@ pub unsafe extern "C" fn __cs_bindgen_describe__example_fn() -> Box<cs_bindgen::
         output: describe::<String>().expect("Failed to generate schema for return type"),
     };
 
-    Box::new(cs_bindgen::shared::serialize_export(export).into())
+    Box::new(serialize_export(export).into())
 }
+
+// When exporting a struct as a handle type (i.e. a class in C#) the ABI conversion
+// simply boxes the value and then returns the pointer as an opaque handle.
+// Additional `From/IntoAbi` impls are generated for references to the type in order
+// to support passing/returning by reference.
 
 pub struct ExampleStruct {
-    _field: String,
+    pub field: String,
 }
 
-impl cs_bindgen::shared::schematic::Describe for ExampleStruct {
+impl Describe for ExampleStruct {
     fn describe<E>(describer: E) -> Result<E::Ok, E::Error>
     where
-        E: cs_bindgen::shared::schematic::Describer,
+        E: Describer,
     {
-        let describer =
-            describer.describe_struct(cs_bindgen::shared::schematic::type_name!(ExampleStruct))?;
-        cs_bindgen::shared::schematic::DescribeStruct::end(describer)
+        let describer = describer.describe_struct(type_name!(ExampleStruct))?;
+        describer.end()
     }
 }
 
-impl cs_bindgen::abi::IntoAbi for ExampleStruct {
+impl IntoAbi for ExampleStruct {
     type Abi = *mut Self;
 
     fn into_abi(self) -> Self::Abi {
@@ -68,7 +74,7 @@ impl cs_bindgen::abi::IntoAbi for ExampleStruct {
     }
 }
 
-impl cs_bindgen::abi::FromAbi for ExampleStruct {
+impl FromAbi for ExampleStruct {
     type Abi = *mut Self;
 
     unsafe fn from_abi(abi: Self::Abi) -> Self {
@@ -76,7 +82,7 @@ impl cs_bindgen::abi::FromAbi for ExampleStruct {
     }
 }
 
-impl<'a> cs_bindgen::abi::IntoAbi for &'a ExampleStruct {
+impl<'a> IntoAbi for &'a ExampleStruct {
     type Abi = Self;
 
     fn into_abi(self) -> Self::Abi {
@@ -84,10 +90,131 @@ impl<'a> cs_bindgen::abi::IntoAbi for &'a ExampleStruct {
     }
 }
 
-impl<'a> cs_bindgen::abi::FromAbi for &'a ExampleStruct {
+impl<'a> FromAbi for &'a ExampleStruct {
     type Abi = Self;
 
     unsafe fn from_abi(abi: Self::Abi) -> Self {
         abi
     }
+}
+
+impl<'a> IntoAbi for &'a mut ExampleStruct {
+    type Abi = *mut ExampleStruct;
+
+    fn into_abi(self) -> Self::Abi {
+        self as *mut _
+    }
+}
+
+impl<'a> FromAbi for &'a mut ExampleStruct {
+    type Abi = *mut ExampleStruct;
+
+    unsafe fn from_abi(abi: Self::Abi) -> Self {
+        &mut *abi
+    }
+}
+
+// For enums, we have two potential ways to handle them:
+//
+// * C-like enums are are simply converted to an integer value.
+// * Data-carrying enums are passed by value, which requires generating an
+//   FFI-compatible representation that values of the enum can be converted
+//   from/into.
+//
+// The raw representation of the enum is a integer discriminant paired with a union
+// of all the fields. The `RawEnum` helper struct pairs the two together.
+
+pub enum SimpleEnum {
+    Foo,
+    Bar,
+    Baz,
+}
+
+impl FromAbi for SimpleEnum {
+    type Abi = isize;
+
+    unsafe fn from_abi(abi: Self::Abi) -> Self {
+        match abi {
+            0 => Self::Foo,
+            1 => Self::Bar,
+            2 => Self::Baz,
+
+            _ => panic!("Unknown discriminant {} for `SimpleEnum`", abi),
+        }
+    }
+}
+
+impl IntoAbi for SimpleEnum {
+    type Abi = isize;
+
+    fn into_abi(self) -> Self::Abi {
+        self as _
+    }
+}
+
+pub enum ComplexEnum {
+    Foo,
+    Bar(String, u32),
+    Baz { first: SimpleEnum, second: String },
+}
+
+impl FromAbi for ComplexEnum {
+    type Abi = RawEnum<isize, ComplexEnumAbi>;
+
+    unsafe fn from_abi(abi: Self::Abi) -> Self {
+        match abi.discriminant {
+            0 => Self::Foo,
+            1 => {
+                let value = ManuallyDrop::into_inner(abi.value.assume_init().Bar);
+                Self::Bar(
+                    FromAbi::from_abi(value.element_0),
+                    FromAbi::from_abi(value.element_1),
+                )
+            }
+            2 => {
+                let value = ManuallyDrop::into_inner(abi.value.assume_init().Baz);
+                Self::Baz {
+                    first: FromAbi::from_abi(value.first),
+                    second: FromAbi::from_abi(value.second),
+                }
+            }
+
+            _ => panic!(
+                "Unknown discriminant {} for `ComplexEnum`",
+                abi.discriminant
+            ),
+        }
+    }
+}
+
+impl IntoAbi for ComplexEnum {
+    type Abi = RawEnum<isize, ComplexEnumAbi>;
+
+    fn into_abi(self) -> Self::Abi {
+        todo!();
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+#[allow(bad_style)]
+pub union ComplexEnumAbi {
+    Bar: ManuallyDrop<ComplexEnumAbi_Bar>,
+    Baz: ManuallyDrop<ComplexEnumAbi_Baz>,
+}
+
+unsafe impl AbiPrimitive for ComplexEnumAbi {}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ComplexEnumAbi_Bar {
+    element_0: <String as FromAbi>::Abi,
+    element_1: <u32 as FromAbi>::Abi,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ComplexEnumAbi_Baz {
+    first: <SimpleEnum as FromAbi>::Abi,
+    second: <String as FromAbi>::Abi,
 }

--- a/cs-bindgen/tests/manual_derive.rs
+++ b/cs-bindgen/tests/manual_derive.rs
@@ -164,6 +164,7 @@ impl FromAbi for ComplexEnum {
     unsafe fn from_abi(abi: Self::Abi) -> Self {
         match abi.discriminant {
             0 => Self::Foo,
+
             1 => {
                 let value = ManuallyDrop::into_inner(abi.value.assume_init().Bar);
                 Self::Bar(
@@ -171,6 +172,7 @@ impl FromAbi for ComplexEnum {
                     FromAbi::from_abi(value.element_1),
                 )
             }
+
             2 => {
                 let value = ManuallyDrop::into_inner(abi.value.assume_init().Baz);
                 Self::Baz {
@@ -191,7 +193,29 @@ impl IntoAbi for ComplexEnum {
     type Abi = RawEnum<isize, ComplexEnumAbi>;
 
     fn into_abi(self) -> Self::Abi {
-        todo!();
+        match self {
+            Self::Foo => RawEnum::simple(0),
+
+            Self::Bar(element_0, element_1) => RawEnum::new(
+                1,
+                ComplexEnumAbi {
+                    Bar: ManuallyDrop::new(ComplexEnumAbi_Bar {
+                        element_0: element_0.into_abi(),
+                        element_1: element_1.into_abi(),
+                    }),
+                },
+            ),
+
+            Self::Baz { first, second } => RawEnum::new(
+                2,
+                ComplexEnumAbi {
+                    Baz: ManuallyDrop::new(ComplexEnumAbi_Baz {
+                        first: first.into_abi(),
+                        second: second.into_abi(),
+                    }),
+                },
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
* Extend the derive functionality in `#[cs_bindgen]` to generate the necessary bindings for data-carrying enums.
* Require that the ABI repr for types implementing `From/IntoAbi` be `Copy`. This required that I tweak the `From/IntoAbi` for `Box`.
* Add `RawEnum` struct to `cs_bindgen::abi`.
* Add test for manually implementing bindings for complex enums.