### PR TITLE
Partially generate bindings for complex enums

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -99,6 +99,15 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 Length = (UIntPtr)len;
             }
         }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct RawEnum<D, V>
+            where D : unmanaged
+            where V : unmanaged
+        {
+            public D Discriminant;
+            public V Value;
+        }
     };
 
     Ok(generated.to_string())

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -28,10 +28,10 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
     let class_name = format_ident!("{}", dll_name.to_camel_case());
 
     // Generate the raw bindings for all exported items.
-    let raw_bindings: Vec<_> = exports
+    let raw_bindings = exports
         .iter()
         .map(|item| quote_raw_binding(item, dll_name))
-        .collect::<Result<_, _>>()?;
+        .collect::<Vec<_>>();
 
     let mut fn_bindings = Vec::new();
     let mut binding_items = Vec::new();

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -1,4 +1,5 @@
-use cs_bindgen_shared::{schematic, schematic::Variant, Enum};
+use crate::generate::quote_cs_type;
+use cs_bindgen_shared::{schematic, schematic::Variant, BindingStyle, Enum};
 use proc_macro2::TokenStream;
 use quote::*;
 
@@ -10,8 +11,7 @@ pub fn quote_enum_binding(item: &Enum) -> TokenStream {
 
     // Determine if we're dealing with a simple (C-like) enum or one with fields.
     if schema.has_data() {
-        // TODO: Generate bindings for enums with data.
-        quote! {}
+        quote_complex_enum_binding(item, schema)
     } else {
         quote_simple_enum_binding(item, schema)
     }
@@ -45,5 +45,47 @@ fn quote_simple_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStre
         public enum #ident {
             #( #variants ),*
         }
+    }
+}
+
+fn quote_complex_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStream {
+    assert_eq!(
+        item.binding_style,
+        BindingStyle::Value,
+        "Right now we only support exporting complex enums by value"
+    );
+
+    let interface = format_ident!("I{}", &*item.name);
+
+    let variant_structs = schema.variants.iter().map(|variant| {
+        let ident = format_ident!("{}", &*variant.name());
+
+        let fields = variant.fields().enumerate().map(|(index, field)| {
+            let field_ident = field
+                .name
+                .as_ref()
+                .map(|name| format_ident!("{}", name))
+                .unwrap_or_else(|| format_ident!("element_{}", index));
+
+            let ty = quote_cs_type(field.schema);
+
+            quote! {
+                public #ty #field_ident
+            }
+        });
+
+        quote! {
+            public struct #ident : #interface {
+                #( #fields; )*
+            }
+        }
+    });
+
+    quote! {
+        // Generate an interface for the enum.
+        public interface #interface {}
+
+        // Generate the struct declarations for each variant of the enum.
+        #( #variant_structs )*
     }
 }

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -1,5 +1,6 @@
 use crate::generate::quote_cs_type;
 use cs_bindgen_shared::{schematic, schematic::Variant, BindingStyle, Enum};
+use heck::*;
 use proc_macro2::TokenStream;
 use quote::*;
 
@@ -64,8 +65,8 @@ fn quote_complex_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStr
             let field_ident = field
                 .name
                 .as_ref()
-                .map(|name| format_ident!("{}", name))
-                .unwrap_or_else(|| format_ident!("element_{}", index));
+                .map(|name| format_ident!("{}", name.to_camel_case()))
+                .unwrap_or_else(|| format_ident!("Element{}", index));
 
             let ty = quote_cs_type(field.schema);
 

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -1,4 +1,4 @@
-use crate::generate::quote_primitive_type;
+use crate::generate::{quote_cs_type, quote_primitive_type};
 use cs_bindgen_shared::*;
 use heck::*;
 use proc_macro2::TokenStream;
@@ -242,53 +242,4 @@ pub fn quote_args<'a>(
         let ty = quote_cs_type(schema);
         quote! { #ty #ident }
     })
-}
-
-/// Generates the idiomatic C# type corresponding to the given type schema.
-pub fn quote_cs_type(schema: &Schema) -> TokenStream {
-    match schema {
-        // NOTE: This is only valid in a return position, it's not valid to have a `void`
-        // argument. An earlier validation pass has already rejected any such cases so we
-        // don't have to differentiate between the two here.
-        Schema::Unit => quote! { void },
-
-        // TODO: Should we be generating more idiomatic return types for numeric types? Any
-        // numeric type that's not `int`, `long`, or `float`/double` is going to be awkward
-        // to use in most cases.
-        //
-        // Tracking issue: https://github.com/randomPoison/cs-bindgen/issues/4
-        Schema::I8 => quote! { sbyte },
-        Schema::I16 => quote! { short },
-        Schema::I32 => quote! { int },
-        Schema::I64 => quote! { long },
-        Schema::U8 => quote! { byte },
-        Schema::U16 => quote! { ushort },
-        Schema::U32 => quote! { uint },
-        Schema::U64 => quote! { ulong },
-        Schema::F32 => quote! { float },
-        Schema::F64 => quote! { double },
-        Schema::Bool => quote! { bool },
-        Schema::String => quote! { string },
-
-        Schema::Char => todo!("Support passing single chars"),
-
-        // TODO: When referencing generated types in function signatures, take custom
-        // namespacing into account. Custom namespaces aren't currently supported, but
-        // once they are it won't be sufficient to directly quote the name of the type.
-        Schema::Struct(schema) => format_ident!("{}", &*schema.name.name).to_token_stream(),
-        Schema::Enum(schema) => format_ident!("{}", &*schema.name.name).to_token_stream(),
-
-        // TODO: Add support for passing user-defined types out from Rust.
-        Schema::UnitStruct(_)
-        | Schema::NewtypeStruct(_)
-        | Schema::TupleStruct(_)
-        | Schema::Option(_)
-        | Schema::Seq(_)
-        | Schema::Tuple(_)
-        | Schema::Map { .. } => todo!("Generate argument binding"),
-
-        Schema::I128 | Schema::U128 => {
-            unreachable!("Invalid argument types should have already been rejected");
-        }
-    }
 }

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "86de159" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "a3112ba" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/integration-tests/TestRunner/EnumTests.cs
+++ b/integration-tests/TestRunner/EnumTests.cs
@@ -19,7 +19,6 @@ namespace TestRunner
         [Fact]
         public void DiscriminantEnumRoundTrip()
         {
-
             foreach (var variant in Enum.GetValues(typeof(EnumWithDiscriminants)).Cast<EnumWithDiscriminants>())
             {
                 EnumWithDiscriminants result = IntegrationTests.RoundtripSimpleEnumWithDiscriminants(variant);

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -129,3 +129,11 @@ pub enum DataEnum {
     Bar(String),
     Baz { name: String, value: i32 },
 }
+
+#[cs_bindgen]
+pub fn generate_data_enum() -> DataEnum {
+    DataEnum::Baz {
+        name: "Randal".into(),
+        value: 11,
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -130,7 +130,7 @@ pub enum DataEnum {
     Baz { name: String, value: i32 },
 }
 
-#[cs_bindgen]
+// #[cs_bindgen]
 pub fn generate_data_enum() -> DataEnum {
     DataEnum::Baz {
         name: "Randal".into(),


### PR DESCRIPTION
First part of the implementation for generating bindings for complex enums. This PR adds logic for generating the interface and variant structs for complex enums, as well as the raw unions and raw variants structs for passing complex enums to/from C#.

At this point, the `#[cs_bindgen]` attribute can be applied to a complex enum and valid bindings will be generated. However, it's still not possible to use `#[cs_bindgen]` on a function that returns a complex enum or takes one as an argument. Some additional refactoring around how user-defined types are handled is needed to do this correctly, so I'm getting this first part of the code generation merged in before I work on that separate cleanup.

Some additional cleanup done in this PR:

* Move the `quote_cs_type` helper method into the `generate` module, since it's now needed for more things than just generating function wrappers.
* Split out more reusable logic for quoting the raw binding types for args/returns, since that's now needed in more places.
* Remove error handling around generating function bindings. The expectation is that we'll either fully support all possible Rust exports, or that we'll add a separate validation pass that catches invalid exports.