### PR TITLE
Unify exports for named types

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -44,9 +44,21 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 export.inputs(),
                 &export.output,
             )),
-            Export::Struct(export) => binding_items.push(quote_struct(export)),
+
+            Export::Named(export) => match &export.schema {
+                Schema::Struct(schema) => binding_items.push(quote_struct(export, schema)),
+                Schema::Enum(schema) => binding_items.push(quote_enum_binding(export, schema)),
+
+                _ => {
+                    return Err(failure::format_err!(
+                        "Invalid schema for exported type {}: {:?}",
+                        export.name,
+                        export.schema
+                    ))
+                }
+            },
+
             Export::Method(export) => binding_items.push(quote_method_binding(export)),
-            Export::Enum(export) => binding_items.push(quote_enum_binding(export)),
         }
     }
 

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -1,5 +1,5 @@
 use crate::generate::func::*;
-use cs_bindgen_shared::{BindingStyle, Method, Schema, Struct};
+use cs_bindgen_shared::{schematic::Struct, BindingStyle, Method, NamedType, Schema};
 use proc_macro2::TokenStream;
 use quote::*;
 use syn::Ident;
@@ -16,7 +16,7 @@ pub fn quote_drop_fn(name: &str, dll_name: &str) -> TokenStream {
     }
 }
 
-pub fn quote_struct(export: &Struct) -> TokenStream {
+pub fn quote_struct(export: &NamedType, _schema: &Struct) -> TokenStream {
     match export.binding_style {
         BindingStyle::Handle => {
             let ident = format_ident!("{}", &*export.name);

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -1,15 +1,10 @@
 use crate::generate::{binding, quote_cs_type};
-use cs_bindgen_shared::{schematic, schematic::Variant, BindingStyle, Enum};
+use cs_bindgen_shared::{schematic::Enum, schematic::Variant, BindingStyle, NamedType};
 use heck::*;
 use proc_macro2::TokenStream;
 use quote::*;
 
-pub fn quote_enum_binding(item: &Enum) -> TokenStream {
-    let schema = item
-        .schema
-        .as_enum()
-        .expect("Enum item's schema does not describe an enum");
-
+pub fn quote_enum_binding(item: &NamedType, schema: &Enum) -> TokenStream {
     // Determine if we're dealing with a simple (C-like) enum or one with fields.
     if schema.has_data() {
         quote_complex_enum_binding(item, schema)
@@ -18,7 +13,7 @@ pub fn quote_enum_binding(item: &Enum) -> TokenStream {
     }
 }
 
-fn quote_simple_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStream {
+fn quote_simple_enum_binding(item: &NamedType, schema: &Enum) -> TokenStream {
     let ident = format_ident!("{}", &*item.name);
     let variants = schema.variants.iter().map(|variant| {
         let (name, discriminant) = match variant {
@@ -49,7 +44,7 @@ fn quote_simple_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStre
     }
 }
 
-fn quote_complex_enum_binding(item: &Enum, schema: &schematic::Enum) -> TokenStream {
+fn quote_complex_enum_binding(item: &NamedType, schema: &Enum) -> TokenStream {
     assert_eq!(
         item.binding_style,
         BindingStyle::Value,

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -42,7 +42,7 @@ pub fn quote_enum_item(item: ItemEnum) -> syn::Result<TokenStream> {
     result.extend(quote! {
         #[no_mangle]
         pub unsafe extern "C" fn #describe_ident() -> std::boxed::Box<cs_bindgen::abi::RawString> {
-            let export = cs_bindgen::shared::Enum {
+            let export = cs_bindgen::shared::NamedType {
                 name: #name.into(),
                 schema: cs_bindgen::shared::schematic::describe::<#ident>().expect("Failed to describe enum type"),
 

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -215,7 +215,7 @@ fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
         // Export a function that describes the exported type.
         #[no_mangle]
         pub unsafe extern "C" fn #describe_ident() -> std::boxed::Box<cs_bindgen::abi::RawString> {
-            let export = cs_bindgen::shared::Struct {
+            let export = cs_bindgen::shared::NamedType {
                 name: #name.into(),
                 binding_style: cs_bindgen::shared::BindingStyle::Handle,
                 schema: cs_bindgen::shared::schematic::describe::<#ident>().expect("Failed to describe struct type"),

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -16,8 +16,7 @@ pub fn serialize_export<E: Into<Export>>(export: E) -> String {
 pub enum Export {
     Fn(Func),
     Method(Method),
-    Struct(Struct),
-    Enum(Enum),
+    Named(NamedType),
 }
 
 /// A free function exported from the Rust lib.
@@ -61,15 +60,16 @@ impl Func {
     }
 }
 
+/// A user-defined type (i.e. a struct or an enum).
+///
+/// Both structs and enums are exported as "named types", since there are a number
+/// of configuration options that are shared for all exported types. To determine
+/// the full details of the exported type, examine the include `schema`.
+///
+/// An exported name type can only be a struct or an enum, as exporting unions is
+/// not supported.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Struct {
-    pub name: Cow<'static, str>,
-    pub binding_style: BindingStyle,
-    pub schema: Schema,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Enum {
+pub struct NamedType {
     pub name: Cow<'static, str>,
     pub binding_style: BindingStyle,
     pub schema: Schema,


### PR DESCRIPTION
Closes #31 

* Replace `Export::Struct` and `Export::Enum` with a unified `Export::Named` variant.
* Export `Struct` and `Enum` structs with a unified `NamedType` struct.