### PR TITLE
Resolve type references when generating C# bindings

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -1,18 +1,20 @@
 use self::{binding::*, class::*, enumeration::*, func::*};
 use crate::Opt;
 use cs_bindgen_shared::{
-    schematic::{Primitive, Schema},
-    Export,
+    schematic::{Primitive, Schema, TypeName},
+    Export, NamedType,
 };
 use heck::*;
 use proc_macro2::TokenStream;
 use quote::*;
-use std::ffi::OsStr;
+use std::{collections::HashMap, ffi::OsStr};
 
 mod binding;
 mod class;
 mod enumeration;
 mod func;
+
+type TypeMap<'a> = HashMap<&'a TypeName, &'a NamedType>;
 
 pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, failure::Error> {
     // TODO: Add a validation pass to detect any invalid types (e.g. 128 bit integers,
@@ -26,6 +28,22 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         .expect("Unable to get name of wasm file");
 
     let class_name = format_ident!("{}", dll_name.to_camel_case());
+
+    // Gather the definitions for all user-defined types so that the full export
+    // information can be retrieved when an export represents another exported type.
+    let type_map = exports
+        .iter()
+        .filter_map(|export| match export {
+            Export::Named(export) => Some((
+                export
+                    .schema
+                    .type_name()
+                    .expect("Named type's schema did not have a type name"),
+                export,
+            )),
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
 
     // Generate the raw bindings for all exported items.
     let raw_bindings = exports
@@ -43,11 +61,14 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 None,
                 export.inputs(),
                 &export.output,
+                &type_map,
             )),
 
             Export::Named(export) => match &export.schema {
                 Schema::Struct(schema) => binding_items.push(quote_struct(export, schema)),
-                Schema::Enum(schema) => binding_items.push(quote_enum_binding(export, schema)),
+                Schema::Enum(schema) => {
+                    binding_items.push(quote_enum_binding(export, schema, &type_map))
+                }
 
                 _ => {
                     return Err(failure::format_err!(
@@ -58,7 +79,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 }
             },
 
-            Export::Method(export) => binding_items.push(quote_method_binding(export)),
+            Export::Method(export) => binding_items.push(quote_method_binding(export, &type_map)),
         }
     }
 
@@ -151,7 +172,7 @@ fn quote_primitive_type(ty: Primitive) -> TokenStream {
 }
 
 /// Generates the idiomatic C# type corresponding to the given type schema.
-fn quote_cs_type(schema: &Schema) -> TokenStream {
+fn quote_cs_type(schema: &Schema, type_map: &TypeMap) -> TokenStream {
     match schema {
         // NOTE: This is only valid in a return position, it's not valid to have a `void`
         // argument. An earlier validation pass has already rejected any such cases so we
@@ -178,11 +199,22 @@ fn quote_cs_type(schema: &Schema) -> TokenStream {
 
         Schema::Char => todo!("Support passing single chars"),
 
-        // TODO: When referencing generated types in function signatures, take custom
-        // namespaces into account. Custom namespaces aren't currently supported, but
-        // once they are it won't be sufficient to directly quote the name of the type.
-        Schema::Struct(schema) => format_ident!("{}", &*schema.name.name).to_token_stream(),
-        Schema::Enum(schema) => format_ident!("{}", &*schema.name.name).to_token_stream(),
+        Schema::Struct(schema) => {
+            let export = type_map
+                .get(&schema.name)
+                .expect("Failed to look up referenced type");
+
+            // TODO: Take into account things like custom namespaces or renaming the type, once
+            // those are supported.
+            format_ident!("{}", &*export.name).into_token_stream()
+        }
+
+        Schema::Enum(schema) => {
+            let export = type_map
+                .get(&schema.name)
+                .expect("Failed to look up referenced type");
+            enumeration::quote_type_reference(&export, schema)
+        }
 
         // TODO: Add support for passing user-defined types out from Rust.
         Schema::UnitStruct(_)

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -5,17 +5,20 @@
 //! from the Rust dylib. This module provides
 
 use crate::generate::{class, quote_primitive_type, TypeMap};
-use cs_bindgen_shared::{schematic::Schema, BindingStyle, Export};
+use cs_bindgen_shared::{
+    schematic::{Enum, Schema, Struct},
+    BindingStyle, Export,
+};
 use proc_macro2::TokenStream;
 use quote::*;
-use syn::{punctuated::Punctuated, token::Comma};
+use syn::{punctuated::Punctuated, token::Comma, Ident};
 
 pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> TokenStream {
     match export {
         Export::Fn(export) => {
             let dll_import_attrib = quote_dll_import(dll_name, &export.binding);
             let binding_ident = format_ident!("{}", &*export.binding);
-            let return_ty = quote_binding_return_type(&export.output);
+            let return_ty = quote_binding_return_type(&export.output, types);
             let args = quote_binding_args(export.inputs(), types);
 
             quote! {
@@ -27,7 +30,7 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
         Export::Method(export) => {
             let dll_import_attrib = quote_dll_import(dll_name, &export.binding);
             let binding_ident = format_ident!("{}", &*export.binding);
-            let return_ty = quote_binding_return_type(&export.output);
+            let return_ty = quote_binding_return_type(&export.output, types);
 
             // TODO: Unify input handling for raw bindings. It shouldn't be necessary to
             // manually insert the receiver. The current blocker is that schematic can't
@@ -71,46 +74,13 @@ pub fn quote_raw_arg(schema: &Schema, types: &TypeMap) -> TokenStream {
 
         Schema::String => quote! { RawCsString },
 
-        Schema::Enum(schema) => {
-            let export = types
-                .get(&schema.name)
-                .expect("Couldn't find exported type for enum");
+        Schema::Enum(schema) => quote_enum_binding(
+            schema,
+            types,
+            format_ident!("{}__RawArg", &*schema.name.name),
+        ),
 
-            match export.binding_style {
-                BindingStyle::Handle => quote! { void* },
-
-                // For enums that are passed by value, the raw representation depends on whether or
-                // not the enum carries additional data:
-                //
-                // * Data-carrying enums are represented as a `RawEnum<T>`, where `T` is a generated
-                //   union type containing the data for the variant.
-                // * C-like enums are represented as a single integer value. The type used for the
-                //   discriminant is either specified directly in the schema, or defaults to
-                //   `isize`/`IntPtr`.
-                BindingStyle::Value => {
-                    if schema.has_data() {
-                        format_ident!("RawEnum<{}__RawArg>", &*export.name).to_token_stream()
-                    } else {
-                        schema
-                            .repr
-                            .map(quote_primitive_type)
-                            .unwrap_or(quote! { IntPtr })
-                    }
-                }
-            }
-        }
-
-        Schema::Struct(schema) => {
-            let export = types
-                .get(&schema.name)
-                .expect("Couldn't find exported type for struct");
-
-            match export.binding_style {
-                BindingStyle::Handle => quote! { void* },
-
-                BindingStyle::Value => todo!("Support passing structs by value"),
-            }
-        }
+        Schema::Struct(schema) => quote_struct_binding(schema, types),
 
         // TODO: Add support for passing user-defined types to Rust.
         Schema::UnitStruct(_)
@@ -127,7 +97,7 @@ pub fn quote_raw_arg(schema: &Schema, types: &TypeMap) -> TokenStream {
     }
 }
 
-pub fn quote_binding_return_type(schema: &Schema) -> TokenStream {
+pub fn quote_binding_return_type(schema: &Schema, types: &TypeMap) -> TokenStream {
     match schema {
         Schema::I8 => quote! { sbyte },
         Schema::I16 => quote! { short },
@@ -147,17 +117,13 @@ pub fn quote_binding_return_type(schema: &Schema) -> TokenStream {
 
         Schema::Unit => quote! { void },
 
-        // TODO: Actually look up the referenced type in the set of exported types and
-        // determine what style of binding is used for it (or if it even has valid bindings
-        // at all). For now, the only supported binding style for user-defined types is to
-        // treat them as a handle, so we hard code that case here.
-        Schema::Struct(_) => quote! { void* },
+        Schema::Struct(schema) => quote_struct_binding(schema, types),
 
-        // TODO: Actually look up the referenced type to determine what style of binding is
-        // being used and what the repr of the discriminant is. For now we only have support
-        // for simple (C-like) enums without an explicit repr, so the raw value will always
-        // be an `isize`.
-        Schema::Enum(_) => quote! { IntPtr },
+        Schema::Enum(schema) => quote_enum_binding(
+            schema,
+            types,
+            format_ident!("{}__RawReturn", &*schema.name.name),
+        ),
 
         // TODO: Add support for passing user-defined types out from Rust.
         Schema::UnitStruct(_)
@@ -170,6 +136,46 @@ pub fn quote_binding_return_type(schema: &Schema) -> TokenStream {
 
         Schema::I128 | Schema::U128 => {
             unreachable!("Invalid types should have already been handled")
+        }
+    }
+}
+
+fn quote_struct_binding(schema: &Struct, types: &TypeMap) -> TokenStream {
+    let export = types
+        .get(&schema.name)
+        .expect("Couldn't find exported type for struct");
+
+    match export.binding_style {
+        BindingStyle::Handle => quote! { void* },
+        BindingStyle::Value => todo!("Support passing structs by value"),
+    }
+}
+
+fn quote_enum_binding(schema: &Enum, types: &TypeMap, raw: Ident) -> TokenStream {
+    let export = types
+        .get(&schema.name)
+        .expect("Couldn't find exported type for enum");
+
+    match export.binding_style {
+        BindingStyle::Handle => quote! { void* },
+
+        // For enums that are passed by value, the raw representation depends on whether or
+        // not the enum carries additional data:
+        //
+        // * Data-carrying enums are represented as a `RawEnum<T>`, where `T` is a generated
+        //   union type containing the data for the variant.
+        // * C-like enums are represented as a single integer value. The type used for the
+        //   discriminant is either specified directly in the schema, or defaults to
+        //   `isize`/`IntPtr`.
+        BindingStyle::Value => {
+            if schema.has_data() {
+                quote! { RawEnum<#raw> }
+            } else {
+                schema
+                    .repr
+                    .map(quote_primitive_type)
+                    .unwrap_or(quote! { IntPtr })
+            }
         }
     }
 }

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -4,19 +4,19 @@
 //! function, using the `[DllImport]` attribute to load the corresponding function
 //! from the Rust dylib. This module provides
 
-use crate::generate::class;
+use crate::generate::{class, quote_primitive_type, TypeMap};
 use cs_bindgen_shared::{schematic::Schema, BindingStyle, Export};
 use proc_macro2::TokenStream;
 use quote::*;
 use syn::{punctuated::Punctuated, token::Comma};
 
-pub fn quote_raw_binding(export: &Export, dll_name: &str) -> TokenStream {
+pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> TokenStream {
     match export {
         Export::Fn(export) => {
             let dll_import_attrib = quote_dll_import(dll_name, &export.binding);
             let binding_ident = format_ident!("{}", &*export.binding);
             let return_ty = quote_binding_return_type(&export.output);
-            let args = quote_binding_args(export.inputs());
+            let args = quote_binding_args(export.inputs(), types);
 
             quote! {
                 #dll_import_attrib
@@ -33,7 +33,7 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str) -> TokenStream {
             // manually insert the receiver. The current blocker is that schematic can't
             // represent reference types, so we can't generate a full list of inputs that
             // includes the receiver.
-            let mut args = quote_binding_args(export.inputs());
+            let mut args = quote_binding_args(export.inputs(), types);
             if export.receiver.is_some() {
                 args.insert(0, quote! { void* self });
             }
@@ -54,7 +54,7 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str) -> TokenStream {
     }
 }
 
-pub fn quote_raw_arg(schema: &Schema) -> TokenStream {
+pub fn quote_raw_arg(schema: &Schema, types: &TypeMap) -> TokenStream {
     match schema {
         Schema::I8 => quote! { sbyte },
         Schema::I16 => quote! { short },
@@ -69,18 +69,51 @@ pub fn quote_raw_arg(schema: &Schema) -> TokenStream {
         Schema::Bool => quote! { byte },
         Schema::Char => quote! { uint },
 
-        // `String` is passed to Rust as a `RawCsString`.
         Schema::String => quote! { RawCsString },
 
-        // TODO: Actually look up the referenced type to determine what style of binding is
-        // being used and what the repr of the discriminant is. For now we only have support
-        // for simple (C-like) enums without an explicit repr, so the raw value will always
-        // be an `isize`.
-        Schema::Enum(_) => quote! { IntPtr },
+        Schema::Enum(schema) => {
+            let export = types
+                .get(&schema.name)
+                .expect("Couldn't find exported type for enum");
+
+            match export.binding_style {
+                BindingStyle::Handle => quote! { void* },
+
+                // For enums that are passed by value, the raw representation depends on whether or
+                // not the enum carries additional data:
+                //
+                // * Data-carrying enums are represented as a `RawEnum<T>`, where `T` is a generated
+                //   union type containing the data for the variant.
+                // * C-like enums are represented as a single integer value. The type used for the
+                //   discriminant is either specified directly in the schema, or defaults to
+                //   `isize`/`IntPtr`.
+                BindingStyle::Value => {
+                    if schema.has_data() {
+                        format_ident!("RawEnum<{}__RawArg>", &*export.name).to_token_stream()
+                    } else {
+                        schema
+                            .repr
+                            .map(quote_primitive_type)
+                            .unwrap_or(quote! { IntPtr })
+                    }
+                }
+            }
+        }
+
+        Schema::Struct(schema) => {
+            let export = types
+                .get(&schema.name)
+                .expect("Couldn't find exported type for struct");
+
+            match export.binding_style {
+                BindingStyle::Handle => quote! { void* },
+
+                BindingStyle::Value => todo!("Support passing structs by value"),
+            }
+        }
 
         // TODO: Add support for passing user-defined types to Rust.
-        Schema::Struct(_)
-        | Schema::UnitStruct(_)
+        Schema::UnitStruct(_)
         | Schema::NewtypeStruct(_)
         | Schema::TupleStruct(_)
         | Schema::Option(_)
@@ -152,11 +185,12 @@ fn quote_dll_import(dll_name: &str, entry_point: &str) -> TokenStream {
 
 fn quote_binding_args<'a>(
     inputs: impl Iterator<Item = (&'a str, &'a Schema)>,
+    types: &TypeMap<'_>,
 ) -> Punctuated<TokenStream, Comma> {
     inputs
         .map(|(name, schema)| {
             let ident = format_ident!("{}", name);
-            let ty = quote_raw_arg(schema);
+            let ty = quote_raw_arg(schema, types);
 
             quote! { #ty #ident }
         })

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -1,4 +1,4 @@
-use crate::generate::func::*;
+use crate::generate::{func::*, TypeMap};
 use cs_bindgen_shared::{schematic::Struct, BindingStyle, Method, NamedType, Schema};
 use proc_macro2::TokenStream;
 use quote::*;
@@ -51,7 +51,7 @@ fn quote_handle_type(name: &Ident, drop_fn: &Ident) -> TokenStream {
     }
 }
 
-pub fn quote_method_binding(item: &Method) -> TokenStream {
+pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
     // Determine the name of the generated wrapper class based on the self type.
     let class_name = match &item.self_type {
         Schema::Struct(struct_) => &struct_.name,
@@ -72,7 +72,7 @@ pub fn quote_method_binding(item: &Method) -> TokenStream {
     // * A static method.
     let wrapper_fn = if is_constructor {
         let binding = format_ident!("{}", &*item.binding);
-        let args = quote_args(item.inputs());
+        let args = quote_args(item.inputs(), type_map);
         let invoke_args = quote_invoke_args(item.inputs());
 
         let invoke = fold_fixed_blocks(
@@ -100,6 +100,7 @@ pub fn quote_method_binding(item: &Method) -> TokenStream {
             Some(quote! { this._handle }),
             item.inputs(),
             &item.output,
+            type_map,
         )
     } else {
         quote_wrapper_fn(
@@ -108,6 +109,7 @@ pub fn quote_method_binding(item: &Method) -> TokenStream {
             None,
             item.inputs(),
             &item.output,
+            type_map,
         )
     };
 

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -116,7 +116,7 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
         });
 
         let return_binding_fields = fields.iter().map(|(field_ident, schema)| {
-            let binding_ty = binding::quote_binding_return_type(schema);
+            let binding_ty = binding::quote_binding_return_type(schema, types);
 
             quote! {
                 internal #binding_ty #field_ident

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -11,14 +11,14 @@ pub fn quote_wrapper_fn<'a>(
     receiver: Option<TokenStream>,
     inputs: impl Iterator<Item = (&'a str, &'a Schema)> + Clone + 'a,
     output: &Schema,
-    type_map: &'a TypeMap,
+    types: &'a TypeMap,
 ) -> TokenStream {
     // Determine the name of the wrapper function. The original function name is
     // going to be in `snake_case`, so we need to convert it to `CamelCase` to keep
     // with C# naming conventions.
     let name = format_ident!("{}", name.to_camel_case());
 
-    let return_ty = quote_cs_type(&output, type_map);
+    let return_ty = quote_cs_type(&output, types);
 
     // Generate the declaration for the output variable and return expression. We need
     // to treat `void` returns as a special case, since C# won't let you declare values
@@ -41,8 +41,8 @@ pub fn quote_wrapper_fn<'a>(
         quote! { static }
     };
 
-    let args = quote_args(inputs.clone(), type_map);
-    let body = quote_wrapper_body(binding, receiver, inputs, output, &ret);
+    let args = quote_args(inputs.clone(), types);
+    let body = quote_wrapper_body(binding, receiver, inputs, output, &ret, types);
 
     quote! {
         public #static_ #return_ty #name(#( #args ),*)
@@ -123,6 +123,7 @@ pub fn quote_wrapper_body<'a>(
     args: impl Iterator<Item = (&'a str, &'a Schema)> + Clone,
     output: &Schema,
     ret: &Ident,
+    types: &TypeMap,
 ) -> TokenStream {
     // Build the list of arguments to the wrapper function and insert the receiver at
     // the beginning of the list of arguments if necessary.
@@ -175,20 +176,37 @@ pub fn quote_wrapper_body<'a>(
 
         Schema::Char => todo!("Support converting a C# `char` into a Rust `char`"),
 
-        // TODO: Look up the referenced type and process the raw return value based on the
-        // type of binding being generated for the type. For now we only support treating
-        // named types as handles, so we always pass the handle to the type's constructor.
+        // NOTE: We don't need to check the binding style when converting structs because
+        // the generated struct will have an overloaded constructor for all supported
+        // binding styles.
         Schema::Struct(output) => {
             let ty_ident = format_ident!("{}", &*output.name.name);
             quote! { #ret = new #ty_ident(#invoke); }
         }
 
-        // TODO: Look up the referenced type and process the raw return value based on the
-        // type of binding being generated for the type. For now we only support treating
-        // named types as handles, so we always pass the handle to the type's constructor.
         Schema::Enum(output) => {
-            let ty_ident = format_ident!("{}", &*output.name.name);
-            quote! { #ret = (#ty_ident)#invoke; }
+            let export = types
+                .get(&output.name)
+                .expect("Couldn't find exported type for enum");
+
+            match export.binding_style {
+                // For handle enums, we directly pass the raw output to the generated class's
+                // constructor.
+                BindingStyle::Handle => {
+                    let ty_ident = format_ident!("{}", &*output.name.name);
+                    quote! { #ret = new #ty_ident(#invoke); }
+                }
+
+                BindingStyle::Value => {
+                    if output.has_data() {
+                        todo!("Generate raw conversion for data-carrying enums")
+                    } else {
+                        // For C-like enums, we simply cast the returned value to the generated enum type.
+                        let ty_ident = format_ident!("{}", &*output.name.name);
+                        quote! { #ret = (#ty_ident)#invoke; }
+                    }
+                }
+            }
         }
 
         // TODO: Add support for passing user-defined types out from Rust.
@@ -205,10 +223,6 @@ pub fn quote_wrapper_body<'a>(
         }
     };
 
-    // Wrap the body of the function in `fixed` blocks for any parameters that need to
-    // be passed as pointers to Rust (just strings for now). We use `Iterator::fold` to
-    // generate a series of nested `fixed` blocks. This is very smart code and won't be
-    // hard to maintain at all, I'm sure.
     fold_fixed_blocks(invoke, args)
 }
 
@@ -216,6 +230,10 @@ pub fn fold_fixed_blocks<'a>(
     base_invoke: TokenStream,
     args: impl Iterator<Item = (&'a str, &'a Schema)>,
 ) -> TokenStream {
+    // Wrap the body of the function in `fixed` blocks for any parameters that need to
+    // be passed as pointers to Rust (just strings for now). We use `Iterator::fold` to
+    // generate a series of nested `fixed` blocks. This is very smart code and won't be
+    // hard to maintain at all, I'm sure.
     args.fold(base_invoke, |body, (name, schema)| match schema {
         Schema::String => {
             let arg_ident = format_ident!("{}", name.to_mixed_case());

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "a3112ba" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "e707fca" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"


### PR DESCRIPTION
Updates the C# code generation logic to build a table of all exported types so that the code generation logic can easily look up the full export information when dealing with type references. The main advantage of this currently is being able to access the binding style for a references type in order to correctly account for binding style in different contexts. This is specifically necessary when dealing with a reference to an enum type, as the generated C# type may be named differently depending on whether the type is marshaled by value or as a handle.

---

* Generate a `TypeMap` from the list of exported items at the start of code generation.
* Update all parts of code generation that handle type references to look up the full export definition as appropriate.