### PR TITLE
Unify ABI traits

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -96,6 +96,12 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 CallingConvention = CallingConvention.Cdecl)]
             internal static extern void __cs_bindgen_drop_string(RustOwnedString raw);
 
+            [DllImport(
+                #dll_name,
+                EntryPoint = "__cs_bindgen_string_from_utf16",
+                CallingConvention = CallingConvention.Cdecl)]
+            internal static extern RustOwnedString __cs_bindgen_string_from_utf16(RawCsString raw);
+
             #( #raw_bindings )*
         }
 

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -108,7 +108,7 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
         });
 
         let arg_binding_fields = fields.iter().map(|(field_ident, schema)| {
-            let binding_ty = binding::quote_raw_arg(schema, types);
+            let binding_ty = binding::quote_type_binding(schema, types);
 
             quote! {
                 internal #binding_ty #field_ident
@@ -116,7 +116,7 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
         });
 
         let return_binding_fields = fields.iter().map(|(field_ident, schema)| {
-            let binding_ty = binding::quote_binding_return_type(schema, types);
+            let binding_ty = binding::quote_type_binding(schema, types);
 
             quote! {
                 internal #binding_ty #field_ident

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -82,7 +82,7 @@ pub fn quote_invoke_args<'a>(
             Schema::String => {
                 let fixed_ident = format_ident!("__fixed_{}", ident);
                 quote! {
-                    new RawCsString(#fixed_ident, #ident.Length)
+                    __bindings.__cs_bindgen_string_from_utf16(new RawCsString(#fixed_ident, #ident.Length))
                 }
             }
 

--- a/cs-bindgen-macro/src/func.rs
+++ b/cs-bindgen-macro/src/func.rs
@@ -61,17 +61,17 @@ pub fn extract_inputs(inputs: Punctuated<FnArg, Comma>) -> syn::Result<Vec<FnInp
 /// This function takes the ident and type of an argument in the original function
 /// and generates the `ident: type` declaration for the corresponding argument in
 /// the binding function. The ident is reused directly, and `Abi` associated type
-/// on the `FromAbi` impl for `ty` is used as the type of the generated argument.
+/// on the `Abi` impl for `ty` is used as the type of the generated argument.
 pub fn quote_binding_inputs<T: ToTokens>(ident: &Ident, ty: T) -> TokenStream {
     quote! {
-        #ident: <#ty as cs_bindgen::abi::FromAbi>::Abi
+        #ident: <#ty as cs_bindgen::abi::Abi>::Abi
     }
 }
 
-/// Generates the call to `FromAbi::from_abi` to convert the raw binding argument.
+/// Generates the call to `Abi::from_abi` to convert the raw binding argument.
 pub fn quote_input_conversion(ident: &Ident) -> TokenStream {
     quote! {
-        let #ident = cs_bindgen::abi::FromAbi::from_abi(#ident);
+        let #ident = cs_bindgen::abi::Abi::from_abi(#ident);
     }
 }
 

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -94,9 +94,9 @@ fn quote_fn_item(item: ItemFn) -> syn::Result<TokenStream> {
         #[no_mangle]
         pub unsafe extern "C" fn #binding_ident(
             #( #binding_inputs, )*
-        ) -> <#return_type as cs_bindgen::abi::IntoAbi>::Abi {
+        ) -> <#return_type as cs_bindgen::abi::Abi>::Abi {
             #( #convert_inputs )*
-            cs_bindgen::abi::IntoAbi::into_abi(#invoke_expr)
+            cs_bindgen::abi::Abi::into_abi(#invoke_expr)
         }
     };
 
@@ -162,50 +162,38 @@ fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
             }
         }
 
-        // Implement `From/IntoAbi` conversions for the type and references to the type.
+        // Implement `Abi` for the type and references to the type.
 
-        impl cs_bindgen::abi::IntoAbi for #ident {
+        impl cs_bindgen::abi::Abi for #ident {
             type Abi = *mut Self;
 
             fn into_abi(self) -> Self::Abi {
                 std::boxed::Box::into_raw(std::boxed::Box::new(self))
             }
-        }
-
-        impl cs_bindgen::abi::FromAbi for #ident {
-            type Abi = *mut Self;
 
             unsafe fn from_abi(abi: Self::Abi) -> Self {
                 *std::boxed::Box::from_raw(abi)
             }
         }
 
-        impl<'a> cs_bindgen::abi::IntoAbi for &'a #ident {
+        impl<'a> cs_bindgen::abi::Abi for &'a #ident {
             type Abi = Self;
 
             fn into_abi(self) -> Self::Abi {
                 self
             }
-        }
-
-        impl<'a> cs_bindgen::abi::FromAbi for &'a #ident {
-            type Abi = Self;
 
             unsafe fn from_abi(abi: Self::Abi) -> Self {
                 abi
             }
         }
 
-        impl<'a> cs_bindgen::abi::IntoAbi for &'a mut #ident {
+        impl<'a> cs_bindgen::abi::Abi for &'a mut #ident {
             type Abi = *mut #ident;
 
             fn into_abi(self) -> Self::Abi {
                 self as *mut _
             }
-        }
-
-        impl<'a> cs_bindgen::abi::FromAbi for &'a mut #ident {
-            type Abi = *mut #ident;
 
             unsafe fn from_abi(abi: Self::Abi) -> Self {
                 &mut *abi
@@ -226,7 +214,7 @@ fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
 
         // Export a function that can be used for dropping an instance of the type.
         #[no_mangle]
-        pub unsafe extern "C" fn #drop_ident(_: <#ident as cs_bindgen::abi::FromAbi>::Abi) {}
+        pub unsafe extern "C" fn #drop_ident(_: <#ident as cs_bindgen::abi::Abi>::Abi) {}
     })
 }
 
@@ -364,9 +352,9 @@ fn quote_method_item(item: ImplItemMethod, self_ty: &Type) -> syn::Result<TokenS
         #[no_mangle]
         pub unsafe extern "C" fn #binding_ident(
             #( #binding_inputs, )*
-        ) -> <#return_type as cs_bindgen::abi::IntoAbi>::Abi {
+        ) -> <#return_type as cs_bindgen::abi::Abi>::Abi {
             #( #convert_inputs )*
-            cs_bindgen::abi::IntoAbi::into_abi(#self_ty::#ident(#( #arg_names, )*))
+            cs_bindgen::abi::Abi::into_abi(#self_ty::#ident(#( #arg_names, )*))
         }
     };
 

--- a/cs-bindgen/src/exports.rs
+++ b/cs-bindgen/src/exports.rs
@@ -14,9 +14,16 @@
 //!
 //! [`export`]: ../macro.export.html
 
-use crate::abi::RawString;
+use crate::abi::{RawSlice, RawString};
 
 /// Drops a `CString` that has been passed to the .NET runtime.
-pub unsafe extern "C" fn __cs_bindgen_drop_string(raw: RawString) {
+pub unsafe fn __cs_bindgen_drop_string(raw: RawString) {
     let _ = raw.into_string();
+}
+
+/// Converts a C# string (i.e. a UTF-16 slice) into a Rust string.
+pub unsafe fn __cs_bindgen_string_from_utf16(raw: RawSlice<u16>) -> RawString {
+    raw.into_string()
+        .expect("Failed to convert C# string to Rust string")
+        .into()
 }

--- a/cs-bindgen/src/lib.rs
+++ b/cs-bindgen/src/lib.rs
@@ -32,5 +32,6 @@ macro_rules! export {
 
     () => {
         $crate::export!(fn __cs_bindgen_drop_string(raw: $crate::abi::RawString));
+        $crate::export!(fn __cs_bindgen_string_from_utf16(raw: $crate::abi::RawSlice<u16>) -> $crate::abi::RawString);
     };
 }

--- a/cs-bindgen/tests/manual_derive.rs
+++ b/cs-bindgen/tests/manual_derive.rs
@@ -48,8 +48,8 @@ pub unsafe extern "C" fn __cs_bindgen_describe__example_fn() -> Box<RawVec<u8>> 
 
 // When exporting a struct as a handle type (i.e. a class in C#) the ABI conversion
 // simply boxes the value and then returns the pointer as an opaque handle.
-// Additional `From/IntoAbi` impls are generated for references to the type in order
-// to support passing/returning by reference.
+// Additional `Abi` impls are generated for references to the type in order to
+// support passing/returning by reference.
 
 pub struct ExampleStruct {
     pub field: String,

--- a/cs-bindgen/tests/simple_enum_derive.rs
+++ b/cs-bindgen/tests/simple_enum_derive.rs
@@ -11,10 +11,7 @@
 //! with each variant, i.e. pass the result of `IntoAbi::into_abi` back through
 //! `FromAbi::from_abi` and then verify that the result matches the original.
 
-use cs_bindgen::{
-    abi::{FromAbi, IntoAbi},
-    prelude::*,
-};
+use cs_bindgen::{abi::Abi, prelude::*};
 use strum::{EnumIter, IntoEnumIterator};
 
 #[test]

--- a/cs-bindgen/tests/simple_enum_derive.rs
+++ b/cs-bindgen/tests/simple_enum_derive.rs
@@ -1,15 +1,15 @@
 //! Tests for verifying that `#[cs_bindgen]` generates the correct bindings for
 //! simple enums (i.e. enums that don't carry extra data).
 //!
-//! These tests primarily verify that the generated `FromAbi` and `IntoAbi` impls
+//! These tests primarily verify that the generated `from_abi` and `into_abi` methods
 //! agree on the discriminant value for each variant of an enum. This is especially
 //! important for simple enums since the generated code needs to correctly handle
 //! custom discriminant values, which may be arbitrary expressions (including
 //! references to constants).
 //!
 //! In order to verify that the implementations are in sync we do a round-trip
-//! with each variant, i.e. pass the result of `IntoAbi::into_abi` back through
-//! `FromAbi::from_abi` and then verify that the result matches the original.
+//! with each variant, i.e. pass the result of `into_abi` back through
+//! `from_abi` and then verify that the result matches the original.
 
 use cs_bindgen::{abi::Abi, prelude::*};
 use strum::{EnumIter, IntoEnumIterator};

--- a/integration-tests/TestRunner/GreetTests.cs
+++ b/integration-tests/TestRunner/GreetTests.cs
@@ -87,6 +87,19 @@ namespace TestRunner
         }
 
         [Fact]
+        public void SetAgeRepeated()
+        {
+            using (PersonInfo info = new PersonInfo("David", 12))
+            {
+                for (var age = 0; age < 100_000; age += 1)
+                {
+                    info.SetAge(age);
+                    Assert.Equal(age, info.Age());
+                }
+            }
+        }
+
+        [Fact]
         public void StaticFunction()
         {
             Assert.Equal(7, PersonInfo.StaticFunction());


### PR DESCRIPTION
Closes #35 

Replace the `FromAbi` and `IntoAbi` traits with a single, unified `Abi` trait. This required a change to how string conversion is done, which is now handled by the `__cs_bindgen_string_from_utf16` function.