### PR TITLE
Handle functions that don't return a value

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -60,7 +60,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 &*export.binding,
                 None,
                 export.inputs(),
-                &export.output,
+                export.output.as_ref(),
                 &types,
             )),
 

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -18,7 +18,10 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
         Export::Fn(export) => {
             let dll_import_attrib = quote_dll_import(dll_name, &export.binding);
             let binding_ident = format_ident!("{}", &*export.binding);
-            let return_ty = quote_type_binding(&export.output, types);
+            let return_ty = match &export.output {
+                Some(output) => quote_type_binding(output, types),
+                None => quote! { void },
+            };
             let args = quote_binding_args(export.inputs(), types);
 
             quote! {
@@ -30,7 +33,10 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
         Export::Method(export) => {
             let dll_import_attrib = quote_dll_import(dll_name, &export.binding);
             let binding_ident = format_ident!("{}", &*export.binding);
-            let return_ty = quote_type_binding(&export.output, types);
+            let return_ty = match &export.output {
+                Some(output) => quote_type_binding(output, types),
+                None => quote! { void },
+            };
 
             // TODO: Unify input handling for raw bindings. It shouldn't be necessary to
             // manually insert the receiver. The current blocker is that schematic can't

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -63,7 +63,7 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
     //
     // TODO: Also support an explicit attribute to specify that a method should (or
     // should not) be treated as a constructor.
-    let is_constructor = item.receiver.is_none() && item.output == item.self_type;
+    let is_constructor = item.receiver.is_none() && item.output == Some(item.self_type);
 
     // Generate the right type of function for the exported method. There are three options:
     //
@@ -99,7 +99,7 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
             &*item.binding,
             Some(quote! { this._handle }),
             item.inputs(),
-            &item.output,
+            item.output.as_ref(),
             type_map,
         )
     } else {
@@ -108,7 +108,7 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
             &*item.binding,
             None,
             item.inputs(),
-            &item.output,
+            item.output.as_ref(),
             type_map,
         )
     };

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -63,7 +63,7 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
     //
     // TODO: Also support an explicit attribute to specify that a method should (or
     // should not) be treated as a constructor.
-    let is_constructor = item.receiver.is_none() && item.output == Some(item.self_type);
+    let is_constructor = item.receiver.is_none() && item.output.as_ref() == Some(&item.self_type);
 
     // Generate the right type of function for the exported method. There are three options:
     //

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -228,7 +228,7 @@ pub fn quote_wrapper_body<'a>(
             }
         },
 
-        None => quote! { #invoke },
+        None => quote! { #invoke; },
     };
 
     fold_fixed_blocks(invoke, args)

--- a/cs-bindgen-macro/src/func.rs
+++ b/cs-bindgen-macro/src/func.rs
@@ -75,16 +75,16 @@ pub fn quote_input_conversion(ident: &Ident) -> TokenStream {
     }
 }
 
-/// Extracts the specified return type for the function, explicitly using `()` for
-/// the default return.
-///
-/// This simplifies the logic needed for quoting the return type of the binding
-/// function, since it removes the need to distinguish between an explicit return vs
-/// the default return (i.e. returning `()`).
-pub fn normalize_return_type(output: &ReturnType) -> TokenStream {
-    // TODO: Generate an error for `impl trait` returns.
-    match output {
-        ReturnType::Default => quote! { () },
-        ReturnType::Type(_, ty) => ty.to_token_stream(),
-    }
-}
+// /// Extracts the specified return type for the function, explicitly using `()` for
+// /// the default return.
+// ///
+// /// This simplifies the logic needed for quoting the return type of the binding
+// /// function, since it removes the need to distinguish between an explicit return vs
+// /// the default return (i.e. returning `()`).
+// pub fn normalize_return_type(output: &ReturnType) -> TokenStream {
+//     // TODO: Generate an error for `impl trait` returns.
+//     match output {
+//         ReturnType::Default => quote! { () },
+//         ReturnType::Type(_, ty) => ty.to_token_stream(),
+//     }
+// }

--- a/cs-bindgen-macro/src/func.rs
+++ b/cs-bindgen-macro/src/func.rs
@@ -74,17 +74,3 @@ pub fn quote_input_conversion(ident: &Ident) -> TokenStream {
         let #ident = cs_bindgen::abi::Abi::from_abi(#ident);
     }
 }
-
-// /// Extracts the specified return type for the function, explicitly using `()` for
-// /// the default return.
-// ///
-// /// This simplifies the logic needed for quoting the return type of the binding
-// /// function, since it removes the need to distinguish between an explicit return vs
-// /// the default return (i.e. returning `()`).
-// pub fn normalize_return_type(output: &ReturnType) -> TokenStream {
-//     // TODO: Generate an error for `impl trait` returns.
-//     match output {
-//         ReturnType::Default => quote! { () },
-//         ReturnType::Type(_, ty) => ty.to_token_stream(),
-//     }
-// }

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -46,7 +46,7 @@ pub struct Func {
     ///
     /// Note that this is the return type of the original function, NOT the generated
     /// binding function.
-    pub output: Schema,
+    pub output: Option<Schema>,
 }
 
 impl Func {
@@ -82,7 +82,7 @@ pub struct Method {
     pub self_type: Schema,
     pub receiver: Option<ReceiverStyle>,
     pub inputs: Vec<(Cow<'static, str>, Schema)>,
-    pub output: Schema,
+    pub output: Option<Schema>,
 }
 
 impl Method {

--- a/cs-bindgen/tests/manual_derive.rs
+++ b/cs-bindgen/tests/manual_derive.rs
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn __cs_bindgen_describe__example_fn() -> Box<RawVec<u8>> 
                 describe::<String>().expect("Failed to generate schema for argument"),
             ),
         ],
-        output: describe::<String>().expect("Failed to generate schema for return type"),
+        output: Some(describe::<String>().expect("Failed to generate schema for return type")),
     };
 
     Box::new(serialize_export(export).into())


### PR DESCRIPTION
The changes made in #37 to unify how ABI conversion is handled also caused the bindings for exported functions that don't return a value to return `u8`. This was a natural outcome of changing zero-sized types to be marshaled as `u8`, however it's slightly inefficient as it requires that the binding function return an unneeded value.

To address this, I've added special case handling for functions that don't declare an explicit return type such that they are correctly generates as `void` functions on the C# side. Functions that explicitly return `()` or another ZST will still have to pass the `u8` value, but this is a reasonable compromise to make in order to correctly handle ZSTs in all cases.