### PR TITLE
Support marshaling data-carrying enums

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -201,32 +201,6 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 Length = (UIntPtr)len;
             }
         }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct RawEnum<V>
-            where V : unmanaged
-        {
-            public IntPtr Discriminant;
-            public V Value;
-
-            public RawEnum(int discriminant, V value)
-            {
-                this.Discriminant = new IntPtr(discriminant);
-                this.Value = value;
-            }
-
-            public RawEnum(long discriminant, V value)
-            {
-                this.Discriminant = new IntPtr(discriminant);
-                this.Value = value;
-            }
-
-            public RawEnum(IntPtr discriminant, V value)
-            {
-                this.Discriminant = discriminant;
-                this.Value = value;
-            }
-        }
     };
 
     Ok(generated.to_string())

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -208,6 +208,24 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         {
             public IntPtr Discriminant;
             public V Value;
+
+            public RawEnum(int discriminant, V value)
+            {
+                this.Discriminant = new IntPtr(discriminant);
+                this.Value = value;
+            }
+
+            public RawEnum(long discriminant, V value)
+            {
+                this.Discriminant = new IntPtr(discriminant);
+                this.Value = value;
+            }
+
+            public RawEnum(IntPtr discriminant, V value)
+            {
+                this.Discriminant = discriminant;
+                this.Value = value;
+            }
         }
     };
 

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -117,13 +117,34 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             internal static ulong __FromRaw(ulong raw) { return raw; }
             internal static float __FromRaw(float raw) { return raw; }
             internal static double __FromRaw(double raw) { return raw; }
-            internal static bool __FromRAw(RustBool raw) { return raw; }
+            internal static bool __FromRaw(RustBool raw) { return raw; }
 
             internal static string __FromRaw(RustOwnedString raw)
             {
                 string result = Encoding.UTF8.GetString(raw.Ptr, (int)raw.Length);
                 __bindings.__cs_bindgen_drop_string(raw);
                 return result;
+            }
+
+            // Overloads of `__IntoRaw` for primitives and built-in types.
+            internal static byte __IntoRaw(byte raw) { return raw; }
+            internal static sbyte __IntoRaw(sbyte raw) { return raw; }
+            internal static short __IntoRaw(short raw) { return raw; }
+            internal static ushort __IntoRaw(ushort raw) { return raw; }
+            internal static int __IntoRaw(int raw) { return raw; }
+            internal static uint __IntoRaw(uint raw) { return raw; }
+            internal static long __IntoRaw(long raw) { return raw; }
+            internal static ulong __IntoRaw(ulong raw) { return raw; }
+            internal static float __IntoRaw(float raw) { return raw; }
+            internal static double __IntoRaw(double raw) { return raw; }
+            internal static RustBool __IntoRaw(bool raw) { return raw; }
+
+            internal static RustOwnedString __IntoRaw(string orig)
+            {
+                fixed (char* origPtr = orig)
+                {
+                    return __cs_bindgen_string_from_utf16(new RawCsString(origPtr, orig.Length));
+                }
             }
         }
 

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -11,7 +11,17 @@ use cs_bindgen_shared::{
 };
 use proc_macro2::TokenStream;
 use quote::*;
-use syn::{punctuated::Punctuated, token::Comma};
+use syn::{punctuated::Punctuated, token::Comma, Ident};
+
+/// Generates the identifier for the from-raw conversion function for the specified type.
+pub fn from_raw_ident(name: &str) -> Ident {
+    format_ident!("__{}FromRaw", name)
+}
+
+/// Generates the identifier for the into-raw conversion function for the specified type.
+pub fn into_raw_ident(name: &str) -> Ident {
+    format_ident!("__{}IntoRaw", name)
+}
 
 pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> TokenStream {
     match export {
@@ -69,8 +79,8 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
             };
 
             // Generate the raw conversion functions for the type.
-            let from_raw = format_ident!("__{}FromRaw", &*export.name);
-            let into_raw = format_ident!("__{}IntoRaw", &*export.name);
+            let from_raw = from_raw_ident(&export.name);
+            let into_raw = into_raw_ident(&export.name);
 
             let raw_fns = match &export.schema {
                 // TODO: Support raw conversions for structs, too!

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -181,29 +181,7 @@ pub fn quote_raw_type_reference(schema: &Schema, types: &TypeMap) -> TokenStream
         Schema::Char => quote! { uint },
         Schema::String => quote! { RustOwnedString },
 
-        Schema::Enum(schema) => {
-            let export = types
-                .get(&schema.name)
-                .expect("Failed to get export for enum");
-            let raw_ident = raw_ident(&schema.name.name);
-
-            // For enums that are marshaled as handles and C-style enums, the raw type uses the
-            // normal raw type naming conventions. For data-carrying enums that are marshaled by
-            // value, the raw type is `RawSchema<>` parameterized with the raw union type for
-            // the enum.
-            //
-            // TODO: If we did away with the generic `RawEnum<>` and instead generated the raw
-            // type for each enum to have the discriminant + data pair, we could simplify this
-            // logic and avoid the need to look up the export information in order to generate
-            // the type binding.
-            if export.binding_style == BindingStyle::Handle || !schema.has_data() {
-                raw_ident.into_token_stream()
-            } else {
-                quote! {
-                    RawEnum<#raw_ident>
-                }
-            }
-        }
+        Schema::Enum(schema) => raw_ident(&schema.name.name).into_token_stream(),
         Schema::Struct(schema) => raw_ident(&schema.name.name).into_token_stream(),
 
         // TODO: Add support for more user-defined types.

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -4,6 +4,11 @@ use proc_macro2::TokenStream;
 use quote::*;
 use syn::Ident;
 
+/// Quotes the pointer type used for handles, i.e. `void*`.
+pub fn quote_handle_ptr() -> TokenStream {
+    quote! { void* }
+}
+
 pub fn quote_drop_fn(name: &str, dll_name: &str) -> TokenStream {
     let binding_ident = format_ident!("__cs_bindgen_drop__{}", name);
     let entry_point = binding_ident.to_string();

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -1,4 +1,4 @@
-use crate::generate::{func::*, TypeMap};
+use crate::generate::{binding, func::*, TypeMap};
 use cs_bindgen_shared::{schematic::Struct, BindingStyle, Method, NamedType, Schema};
 use proc_macro2::TokenStream;
 use quote::*;
@@ -18,11 +18,7 @@ pub fn quote_drop_fn(name: &str, dll_name: &str) -> TokenStream {
 
 pub fn quote_struct(export: &NamedType, _schema: &Struct) -> TokenStream {
     match export.binding_style {
-        BindingStyle::Handle => {
-            let ident = format_ident!("{}", &*export.name);
-            let drop_fn = format_ident!("__cs_bindgen_drop__{}", &*export.name);
-            quote_handle_type(&ident, &drop_fn)
-        }
+        BindingStyle::Handle => quote_handle_type(export),
 
         BindingStyle::Value => unimplemented!("Pass struct by value"),
     }
@@ -33,15 +29,19 @@ fn quote_handle_ptr() -> TokenStream {
     quote! { void* }
 }
 
-fn quote_handle_type(name: &Ident, drop_fn: &Ident) -> TokenStream {
+fn quote_handle_type(export: &NamedType) -> TokenStream {
+    let ident = format_ident!("{}", &*export.name);
+    let drop_fn = format_ident!("__cs_bindgen_drop__{}", &*export.name);
+    let raw_repr = binding::raw_ident(&export.name);
+
     quote! {
-        public unsafe partial class #name : IDisposable
+        public unsafe partial class #ident : IDisposable
         {
             internal void* _handle;
 
-            internal #name(void* handle)
+            internal #ident(#raw_repr raw)
             {
-                _handle = handle;
+                _handle = raw.Handle;
             }
 
             public void Dispose()
@@ -51,6 +51,18 @@ fn quote_handle_type(name: &Ident, drop_fn: &Ident) -> TokenStream {
                     __bindings.#drop_fn(_handle);
                     _handle = null;
                 }
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal unsafe struct #raw_repr
+        {
+            [FieldOffset(0)]
+            public void* Handle;
+
+            public #raw_repr(#ident orig)
+            {
+                this.Handle = orig._handle;
             }
         }
     }
@@ -81,7 +93,7 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
         let invoke_args = quote_invoke_args(item.inputs());
 
         let invoke = fold_fixed_blocks(
-            quote! { _handle = __bindings.#binding(#invoke_args); },
+            quote! { _handle = __bindings.#binding(#invoke_args).Handle; },
             item.inputs(),
         );
 

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -4,11 +4,6 @@ use proc_macro2::TokenStream;
 use quote::*;
 use syn::Ident;
 
-/// Quotes the pointer type used for handles, i.e. `void*`.
-pub fn quote_handle_ptr() -> TokenStream {
-    quote! { void* }
-}
-
 pub fn quote_drop_fn(name: &str, dll_name: &str) -> TokenStream {
     let binding_ident = format_ident!("__cs_bindgen_drop__{}", name);
     let entry_point = binding_ident.to_string();
@@ -33,11 +28,16 @@ pub fn quote_struct(export: &NamedType, _schema: &Struct) -> TokenStream {
     }
 }
 
+/// Quotes the pointer type used for handles, i.e. `void*`.
+fn quote_handle_ptr() -> TokenStream {
+    quote! { void* }
+}
+
 fn quote_handle_type(name: &Ident, drop_fn: &Ident) -> TokenStream {
     quote! {
         public unsafe partial class #name : IDisposable
         {
-            private void* _handle;
+            internal void* _handle;
 
             internal #name(void* handle)
             {

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -21,32 +21,6 @@ pub fn quote_type_reference(export: &NamedType, schema: &Enum) -> TokenStream {
     }
 }
 
-/// Quotes the name of the generated C# type for the exported enum.
-///
-/// There are three possible raw representations for an enum:
-///
-/// * For C-like enums, the raw representation is the integer type used for the
-///   enum's discriminant.
-/// * For data-carrying enums that are marshaled by value, the raw representation is
-/// * For enums that are marshalled as handles, the raw representation is just the
-///   handle pointer type (`void*`).
-pub fn quote_raw_type_reference(export: &NamedType, schema: &Enum) -> TokenStream {
-    match export.binding_style {
-        BindingStyle::Value => {
-            if schema.has_data() {
-                let union_ty = binding::raw_ident(&export.name);
-                quote! {
-                    RawEnum<#union_ty>
-                }
-            } else {
-                quote_discriminant_type(schema)
-            }
-        }
-
-        BindingStyle::Handle => class::quote_handle_ptr(),
-    }
-}
-
 /// Quotes the appropriate discriminant type for the specified enum type.
 ///
 /// The generated type is the type use to represent the raw discriminant when

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -187,7 +187,7 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
         });
 
         let arg_binding_fields = fields.iter().map(|(field_ident, schema)| {
-            let binding_ty = binding::quote_type_binding(schema, types);
+            let binding_ty = binding::quote_raw_type_reference(schema, types);
 
             quote! {
                 #binding_ty #field_ident

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -140,77 +140,13 @@ pub fn quote_wrapper_body<'a>(
 
     // Generate the expression for invoking the raw binding and then converting the raw
     // return value into the appropriate C# type.
+    let from_raw = binding::from_raw_fn_ident();
     let invoke = quote! { #binding(#invoke_args) };
 
-    // TODO: Use the generic `__FromRaw` logic to handle type conversions in a unified
-    // way. We'll need to tweak how we handle enum discriminants slightly to make sure
-    // we can reliably overload `__FromRaw` such that different enum types with the same
-    // discriminant type have distinct overloads.
+    // Handle difference in how binding function needs to be invoked depending on
+    // whether or not the function returns a value.
     let invoke = match output {
-        Some(output) => match output {
-            // NOTE: For `void` returns there's no intermediate variable for the return value
-            // (since we can't have a `void` variable).
-            Schema::Unit => quote! { #invoke; },
-
-            // Basic numeric types (currently) don't require any processing.
-            Schema::I8
-            | Schema::I16
-            | Schema::I32
-            | Schema::I64
-            | Schema::U8
-            | Schema::U16
-            | Schema::U32
-            | Schema::U64
-            | Schema::F32
-            | Schema::F64 => quote! { #ret = #invoke; },
-
-            // `bool` is returned as a `u8`, so we do an explicit comparison to convert it back
-            // to a `bool` on the C# side.
-            Schema::Bool => quote! { #ret = #invoke != 0; },
-
-            // To pass a string to Rust, we convert it into a `RawCsString` with the fixed pointer.
-            // The code for wrapping the body of the function in a `fixed` block is done below,
-            // since we need to generate the contents of the block first.
-            //
-            // Once we decode the Rust string into a C# string, we also need to drop the original
-            // Rust string.
-            Schema::String => quote! {
-                var __raw_result = #invoke;
-                #ret = Encoding.UTF8.GetString(__raw_result.Ptr, (int)__raw_result.Length);
-                __bindings.__cs_bindgen_drop_string(__raw_result);
-            },
-
-            Schema::Char => todo!("Support converting a C# `char` into a Rust `char`"),
-
-            // NOTE: We don't need to check the binding style when converting structs because
-            // the generated struct will have an overloaded constructor for all supported
-            // binding styles.
-            //
-            // TODO: Use the same `__FromRaw` conversion style as we do for enums.
-            Schema::Struct(output) => {
-                let ty_ident = format_ident!("{}", &*output.name.name);
-                quote! { #ret = new #ty_ident(#invoke); }
-            }
-
-            Schema::Enum(_) => {
-                let from_raw = binding::from_raw_fn_ident(output);
-                quote! { #ret = __bindings.#from_raw(#invoke); }
-            }
-
-            // TODO: Add support for passing user-defined types out from Rust.
-            Schema::UnitStruct(_)
-            | Schema::NewtypeStruct(_)
-            | Schema::TupleStruct(_)
-            | Schema::Option(_)
-            | Schema::Seq(_)
-            | Schema::Tuple(_)
-            | Schema::Map { .. } => todo!("Generate return value conversion in wrapper function"),
-
-            Schema::I128 | Schema::U128 => {
-                unreachable!("Invalid argument types should have already been rejected");
-            }
-        },
-
+        Some(_) => quote! { #ret = __bindings.#from_raw(#invoke); },
         None => quote! { #invoke; },
     };
 

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -141,6 +141,11 @@ pub fn quote_wrapper_body<'a>(
     // Generate the expression for invoking the raw binding and then converting the raw
     // return value into the appropriate C# type.
     let invoke = quote! { #binding(#invoke_args) };
+
+    // TODO: Use the generic `__FromRaw` logic to handle type conversions in a unified
+    // way. We'll need to tweak how we handle enum discriminants slightly to make sure
+    // we can reliably overload `__FromRaw` such that different enum types with the same
+    // discriminant type have distinct overloads.
     let invoke = match output {
         Some(output) => match output {
             // NOTE: For `void` returns there's no intermediate variable for the return value
@@ -187,8 +192,8 @@ pub fn quote_wrapper_body<'a>(
                 quote! { #ret = new #ty_ident(#invoke); }
             }
 
-            Schema::Enum(output) => {
-                let from_raw = binding::from_raw_fn_ident(&output.name.name);
+            Schema::Enum(_) => {
+                let from_raw = binding::from_raw_fn_ident(output);
                 quote! { #ret = __bindings.#from_raw(#invoke); }
             }
 

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -188,7 +188,7 @@ pub fn quote_wrapper_body<'a>(
             }
 
             Schema::Enum(output) => {
-                let from_raw = binding::from_raw_ident(&output.name.name);
+                let from_raw = binding::from_raw_fn_ident(&output.name.name);
                 quote! { #ret = __bindings.#from_raw(#invoke); }
             }
 

--- a/integration-tests/TestRunner/EnumTests.cs
+++ b/integration-tests/TestRunner/EnumTests.cs
@@ -25,5 +25,27 @@ namespace TestRunner
                 Assert.Equal(variant, result);
             }
         }
+
+        [Fact]
+        public void GenerateDataEnum()
+        {
+            IDataEnum value = IntegrationTests.GenerateDataEnum();
+            Baz baz = (Baz)value;
+            Assert.Equal("Randal", baz.Name);
+            Assert.Equal(11, baz.Value);
+        }
+
+        [Fact]
+        public void DataEnumRoundTrip()
+        {
+            var foo = new Foo();
+            Assert.Equal(foo, IntegrationTests.RoundtripDataEnum(foo));
+
+            var bar = new Bar() { Element0 = "What a cool enum!" };
+            Assert.Equal(bar, IntegrationTests.RoundtripDataEnum(bar));
+
+            var baz = new Baz { Name = "Cool Guy McGee", Value = 69 };
+            Assert.Equal(baz, IntegrationTests.RoundtripDataEnum(baz));
+        }
     }
 }

--- a/integration-tests/TestRunner/EnumTests.cs
+++ b/integration-tests/TestRunner/EnumTests.cs
@@ -38,14 +38,26 @@ namespace TestRunner
         [Fact]
         public void DataEnumRoundTrip()
         {
-            var foo = new Foo();
-            Assert.Equal(foo, IntegrationTests.RoundtripDataEnum(foo));
+            {
+                var orig = new Foo();
+                var result = (Foo)IntegrationTests.RoundtripDataEnum(orig);
+                Assert.Equal(orig, result);
+            }
 
-            var bar = new Bar() { Element0 = "What a cool enum!" };
-            Assert.Equal(bar, IntegrationTests.RoundtripDataEnum(bar));
+            {
+                var orig = new Bar() { Element0 = "What a cool enum!" };
+                var result = (Bar)IntegrationTests.RoundtripDataEnum(orig);
+                Assert.Equal(orig, result);
+                Assert.Equal(orig.Element0, result.Element0);
+            }
 
-            var baz = new Baz { Name = "Cool Guy McGee", Value = 69 };
-            Assert.Equal(baz, IntegrationTests.RoundtripDataEnum(baz));
+            {
+                var orig = new Baz { Name = "Cool Guy McGee", Value = 69 };
+                var result = (Baz)IntegrationTests.RoundtripDataEnum(orig);
+                Assert.Equal(orig, result);
+                Assert.Equal(orig.Name, result.Name);
+                Assert.Equal(orig.Value, result.Value);
+            }
         }
     }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -131,6 +131,11 @@ pub enum DataEnum {
 }
 
 #[cs_bindgen]
+pub fn roundtrip_data_enum(val: DataEnum) -> DataEnum {
+    val
+}
+
+#[cs_bindgen]
 pub fn generate_data_enum() -> DataEnum {
     DataEnum::Baz {
         name: "Randal".into(),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -130,7 +130,7 @@ pub enum DataEnum {
     Baz { name: String, value: i32 },
 }
 
-// #[cs_bindgen]
+#[cs_bindgen]
 pub fn generate_data_enum() -> DataEnum {
     DataEnum::Baz {
         name: "Randal".into(),


### PR DESCRIPTION
This PR adds full support for marshaling data-carrying enums by value, e.g.:

```rust
#[cs_bindgen]
pub enum MyEnum {
    Foo(i32),
    Bar {
        name: String,
        value: i32,
    },
    Baz,
}
```

I changed type marshaling logic on the C# side to use a generic solution based on overloads of `__FromRaw` and `__IntoRaw` methods on the `__bindings` class. This makes it possible to easily do deep structural conversion of types while minimizing complexity in the code generation logic. In order to make this work, though, we now need to generate a bespoke "raw" representation for every exported type, even when the ABI representation on the Rust side is a primitive type.

We're using `[StructLayout(LayoutKind.Explicit)]` and `[FieldOffset(0)]` in the hopes that this will have a similar effect to `#[repr(transparent)]` in Rust and make the marshaling sound, however we'll likely need to revisit it at some point and make sure everything is guaranteed to work as intended. This also applies for bools, which now have a `RustBool` raw representation, and handle types, which have a raw struct that is a wrapper around a `void*`.

I've also had to remove the generic `RawEnum<>` helper struct and instead generate a bespoke raw enum representation for each exported data-carrying enum. This was necessary because generic types can't be be marshaled by C#, and it had the added benefit of further simplifying the code generation for raw bindings.