### PR TITLE
Remove errant #[derive(Debug)] on generated types

### DIFF
--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -175,7 +175,7 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
 
         Some(quote! {
             #[repr(C)]
-            #[derive(Debug, Clone, Copy)]
+            #[derive(Clone, Copy)]
             #[allow(bad_style)]
             pub struct #abi_ident {
                 #( #from_fields, )*

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -96,6 +96,7 @@ pub fn void_return(test: i32) {
 }
 
 #[cs_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SimpleCEnum {
     Foo,
     Bar,
@@ -108,6 +109,7 @@ pub fn roundtrip_simple_enum(val: SimpleCEnum) -> SimpleCEnum {
 }
 
 #[cs_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EnumWithDiscriminants {
     Hello,
     There = 5,
@@ -124,10 +126,27 @@ pub fn roundtrip_simple_enum_with_discriminants(
 }
 
 #[cs_bindgen]
+#[derive(Debug, Clone)]
 pub enum DataEnum {
     Foo,
     Bar(String),
     Baz { name: String, value: i32 },
+    Coolness(InnerEnum),
+    NestedStruct(InnerStruct),
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub enum InnerEnum {
+    Cool(SimpleCEnum),
+    Cooler(SimpleCEnum),
+    Coolest(SimpleCEnum),
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct InnerStruct {
+    pub value: i32,
 }
 
 #[cs_bindgen]
@@ -141,4 +160,10 @@ pub fn generate_data_enum() -> DataEnum {
         name: "Randal".into(),
         value: 11,
     }
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct WrapperType {
+    pub value: DataEnum,
 }


### PR DESCRIPTION
Fixes an error that would happen if you had if a data-carrying enum was nested inside another data-carrying enum. Added a regression test to the integration test suite to cover this case.