### PR TITLE
Prevent name collisions between enum variants and other types

### DIFF
--- a/cs-bindgen-cli/Cargo.toml
+++ b/cs-bindgen-cli/Cargo.toml
@@ -10,7 +10,7 @@ failure = "0.1.6"
 heck = "0.3.1"
 parity-wasm = "0.41.0"
 proc-macro2 = "1.0.8"
-quote = "1.0.2"
+quote = "1.0.3"
 serde_json = "1.0.45"
 structopt = "0.3.8"
 syn = { version = "1.0.14", features = ["full"] }

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -264,16 +264,24 @@ fn quote_cs_type(schema: &Schema, type_map: &TypeMap) -> TokenStream {
                 .get(&schema.name)
                 .expect("Failed to look up referenced type");
 
+            let ident = format_ident!("{}", &*export.name).into_token_stream();
+
             // TODO: Take into account things like custom namespaces or renaming the type, once
-            // those are supported.
-            format_ident!("{}", &*export.name).into_token_stream()
+            // those are supported. For now, we manually prefix references to user-defined types
+            // with `global::` in order to avoid name collisions. Once we support custom
+            // namespaces, we'll want to use the correct namespace name instead.
+            quote! { global::#ident }
         }
 
         Schema::Enum(schema) => {
             let export = type_map
                 .get(&schema.name)
                 .expect("Failed to look up referenced type");
-            enumeration::quote_type_reference(&export, schema)
+            let ident = enumeration::quote_type_reference(&export, schema);
+
+            // TODO: Once custom namespaces are supported, use the appropriate namespace instead
+            // of `global::`.
+            quote! { global::#ident }
         }
 
         // TODO: Add support for passing user-defined types out from Rust.

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -181,8 +181,19 @@ pub fn quote_raw_type_reference(schema: &Schema, types: &TypeMap) -> TokenStream
         Schema::Char => quote! { uint },
         Schema::String => quote! { RustOwnedString },
 
-        Schema::Enum(schema) => raw_ident(&schema.name.name).into_token_stream(),
-        Schema::Struct(schema) => raw_ident(&schema.name.name).into_token_stream(),
+        Schema::Enum(schema) => {
+            let ident = raw_ident(&schema.name.name);
+            quote! {
+                global::#ident
+            }
+        }
+
+        Schema::Struct(schema) => {
+            let ident = raw_ident(&schema.name.name);
+            quote! {
+                global::#ident
+            }
+        }
 
         // TODO: Add support for more user-defined types.
         Schema::UnitStruct(_)

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -1,4 +1,4 @@
-use crate::generate::{binding, quote_cs_type, quote_primitive_type, TypeMap};
+use crate::generate::{self, binding, quote_primitive_type, TypeMap};
 use cs_bindgen_shared::{schematic::Enum, schematic::Variant, BindingStyle, NamedType};
 use heck::*;
 use proc_macro2::{Literal, TokenStream};
@@ -240,7 +240,7 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
             .collect::<Vec<_>>();
 
         let struct_fields = fields.iter().map(|(field_ident, schema)| {
-            let ty = quote_cs_type(schema, types);
+            let ty = generate::quote_cs_type(schema, types);
             quote! {
                 #ty #field_ident
             }
@@ -381,7 +381,7 @@ fn variant_struct_type_ref(export: &NamedType, variant: &Variant) -> TokenStream
     }
 }
 
-fn raw_variant_struct_type_ref(export: &NamedType, variant: &Variant) -> TokenStream {
+pub fn raw_variant_struct_type_ref(export: &NamedType, variant: &Variant) -> TokenStream {
     let wrapper_class = wrapper_class_name(export);
     let raw_variant_struct_name = binding::raw_ident(variant.name());
     quote! {

--- a/integration-tests/TestRunner/EnumTests.cs
+++ b/integration-tests/TestRunner/EnumTests.cs
@@ -30,7 +30,7 @@ namespace TestRunner
         public void GenerateDataEnum()
         {
             IDataEnum value = IntegrationTests.GenerateDataEnum();
-            Baz baz = (Baz)value;
+            var baz = (DataEnum.Baz)value;
             Assert.Equal("Randal", baz.Name);
             Assert.Equal(11, baz.Value);
         }
@@ -39,21 +39,21 @@ namespace TestRunner
         public void DataEnumRoundTrip()
         {
             {
-                var orig = new Foo();
-                var result = (Foo)IntegrationTests.RoundtripDataEnum(orig);
+                var orig = new DataEnum.Foo();
+                var result = (DataEnum.Foo)IntegrationTests.RoundtripDataEnum(orig);
                 Assert.Equal(orig, result);
             }
 
             {
-                var orig = new Bar() { Element0 = "What a cool enum!" };
-                var result = (Bar)IntegrationTests.RoundtripDataEnum(orig);
+                var orig = new DataEnum.Bar() { Element0 = "What a cool enum!" };
+                var result = (DataEnum.Bar)IntegrationTests.RoundtripDataEnum(orig);
                 Assert.Equal(orig, result);
                 Assert.Equal(orig.Element0, result.Element0);
             }
 
             {
-                var orig = new Baz { Name = "Cool Guy McGee", Value = 69 };
-                var result = (Baz)IntegrationTests.RoundtripDataEnum(orig);
+                var orig = new DataEnum.Baz { Name = "Cool Guy McGee", Value = 69 };
+                var result = (DataEnum.Baz)IntegrationTests.RoundtripDataEnum(orig);
                 Assert.Equal(orig, result);
                 Assert.Equal(orig.Name, result.Name);
                 Assert.Equal(orig.Value, result.Value);

--- a/integration-tests/src/data_enum.rs
+++ b/integration-tests/src/data_enum.rs
@@ -1,0 +1,39 @@
+use crate::simple_enum::SimpleCEnum;
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub enum DataEnum {
+    Foo,
+    Bar(String),
+    Baz { name: String, value: i32 },
+    Coolness(InnerEnum),
+    NestedStruct(InnerStruct),
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub enum InnerEnum {
+    Cool(SimpleCEnum),
+    Cooler(SimpleCEnum),
+    Coolest(SimpleCEnum),
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub struct InnerStruct {
+    pub value: i32,
+}
+
+#[cs_bindgen]
+pub fn roundtrip_data_enum(val: DataEnum) -> DataEnum {
+    val
+}
+
+#[cs_bindgen]
+pub fn generate_data_enum() -> DataEnum {
+    DataEnum::Baz {
+        name: "Randal".into(),
+        value: 11,
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,4 +1,9 @@
+use crate::data_enum::DataEnum;
 use cs_bindgen::prelude::*;
+
+pub mod data_enum;
+pub mod name_collision;
+pub mod simple_enum;
 
 // Re-export core cs_bindgen functionality. Required in order for the generated Wasm module.
 cs_bindgen::export!();
@@ -93,73 +98,6 @@ impl Address {
 #[cs_bindgen]
 pub fn void_return(test: i32) {
     println!("{}", test);
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SimpleCEnum {
-    Foo,
-    Bar,
-    Baz,
-}
-
-#[cs_bindgen]
-pub fn roundtrip_simple_enum(val: SimpleCEnum) -> SimpleCEnum {
-    val
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum EnumWithDiscriminants {
-    Hello,
-    There = 5,
-    How,
-    Are,
-    You = -12,
-}
-
-#[cs_bindgen]
-pub fn roundtrip_simple_enum_with_discriminants(
-    val: EnumWithDiscriminants,
-) -> EnumWithDiscriminants {
-    val
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone)]
-pub enum DataEnum {
-    Foo,
-    Bar(String),
-    Baz { name: String, value: i32 },
-    Coolness(InnerEnum),
-    NestedStruct(InnerStruct),
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone)]
-pub enum InnerEnum {
-    Cool(SimpleCEnum),
-    Cooler(SimpleCEnum),
-    Coolest(SimpleCEnum),
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone)]
-pub struct InnerStruct {
-    pub value: i32,
-}
-
-#[cs_bindgen]
-pub fn roundtrip_data_enum(val: DataEnum) -> DataEnum {
-    val
-}
-
-#[cs_bindgen]
-pub fn generate_data_enum() -> DataEnum {
-    DataEnum::Baz {
-        name: "Randal".into(),
-        value: 11,
-    }
 }
 
 #[cs_bindgen]

--- a/integration-tests/src/name_collision.rs
+++ b/integration-tests/src/name_collision.rs
@@ -1,0 +1,15 @@
+//! This module tests cases where generated types can potentially have name collisions.
+
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub struct Test {
+    pub value: i32,
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub enum TestEnum {
+    Test(Test),
+}

--- a/integration-tests/src/simple_enum.rs
+++ b/integration-tests/src/simple_enum.rs
@@ -1,0 +1,31 @@
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SimpleCEnum {
+    Foo,
+    Bar,
+    Baz,
+}
+
+#[cs_bindgen]
+pub fn roundtrip_simple_enum(val: SimpleCEnum) -> SimpleCEnum {
+    val
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EnumWithDiscriminants {
+    Hello,
+    There = 5,
+    How,
+    Are,
+    You = -12,
+}
+
+#[cs_bindgen]
+pub fn roundtrip_simple_enum_with_discriminants(
+    val: EnumWithDiscriminants,
+) -> EnumWithDiscriminants {
+    val
+}


### PR DESCRIPTION
Change how data-carrying enums are represented in C# to put the structs for the variants inside a wrapper class. This effectively namespaces the variants such that they won't collide if a variant has the same name as another type in the same namespace.

This also has the added benefit of making data-carrying enums feel a bit more like regular enums on the C# side. For example, the following exported enum:

```rust
#[cs_bindgen]
pub enum MyEnum {
    Foo,
    Bar { name: String },
}
```

Is used like this on the C# side:

```csharp
let value = new MyEnum.Foo();

switch (value)
{
    case MyEnum.Foo foo:
        // ...

    case MyEnum.Bar bar:
        // ...
}
```

---

In order to better handle naming collisions, I've updated the bits of code that generate type references to fully-qualify the generated type name for all user-defined types. For now that just means prefixing them with `global::`, but this can be extended to include the full namespace once custom namespaces are supported.