### PR TITLE
Support marshaling structs by value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "strukt"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "cSpell.words": [
-        "strukt"
-    ]
-}

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -13,6 +13,7 @@ mod binding;
 mod class;
 mod enumeration;
 mod func;
+mod strukt;
 
 type TypeMap<'a> = HashMap<&'a TypeName, &'a NamedType>;
 
@@ -65,7 +66,10 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             )),
 
             Export::Named(export) => match &export.schema {
-                Schema::Struct(schema) => binding_items.push(quote_struct(export, schema)),
+                Schema::Struct(schema) => {
+                    binding_items.push(strukt::quote_struct(export, schema, &types))
+                }
+
                 Schema::Enum(schema) => {
                     binding_items.push(quote_enum_binding(export, schema, &types))
                 }

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -236,7 +236,7 @@ fn quote_primitive_type(ty: Primitive) -> TokenStream {
 }
 
 /// Generates the idiomatic C# type corresponding to the given type schema.
-fn quote_cs_type(schema: &Schema, type_map: &TypeMap) -> TokenStream {
+fn quote_cs_type(schema: &Schema, types: &TypeMap) -> TokenStream {
     match schema {
         // NOTE: This is only valid in a return position, it's not valid to have a `void`
         // argument. An earlier validation pass has already rejected any such cases so we
@@ -264,7 +264,7 @@ fn quote_cs_type(schema: &Schema, type_map: &TypeMap) -> TokenStream {
         Schema::Char => todo!("Support passing single chars"),
 
         Schema::Struct(schema) => {
-            let export = type_map
+            let export = types
                 .get(&schema.name)
                 .expect("Failed to look up referenced type");
 
@@ -278,7 +278,7 @@ fn quote_cs_type(schema: &Schema, type_map: &TypeMap) -> TokenStream {
         }
 
         Schema::Enum(schema) => {
-            let export = type_map
+            let export = types
                 .get(&schema.name)
                 .expect("Failed to look up referenced type");
             let ident = enumeration::quote_type_reference(&export, schema);

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -76,7 +76,8 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
             // includes the receiver.
             let mut args = quote_binding_args(export.inputs(), types);
             if export.receiver.is_some() {
-                args.insert(0, quote! { void* self });
+                let handle_type = class::quote_handle_ptr();
+                args.insert(0, quote! { #handle_type self });
             }
 
             quote! {

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -129,12 +129,8 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
 
                 BindingStyle::Value => match &export.schema {
                     Schema::Struct(_) => {
-                        let from_raw_impl = quote! {
-                            throw new NotImplementedException("Support passing structs by value");
-                        };
-                        let into_raw_impl = quote! {
-                            throw new NotImplementedException("Support passing structs by value");
-                        };
+                        let from_raw_impl = quote! { return new #cs_repr(raw); };
+                        let into_raw_impl = quote! { return new #raw_repr(self); };
 
                         (from_raw_impl, into_raw_impl)
                     }

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -166,7 +166,10 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
 }
 
 /// Generates the appropriate raw type name for the given type schema.
-pub fn quote_raw_type_reference(schema: &Schema, types: &TypeMap) -> TokenStream {
+// NOTE: We're not currently using the type map parameter, but we'll eventually need
+// it once we support custom namespaces, since we'll need to look up the export
+// information to determine the fully-qualified name for the type.
+pub fn quote_raw_type_reference(schema: &Schema, _types: &TypeMap) -> TokenStream {
     match schema {
         Schema::I8 => quote! { sbyte },
         Schema::I16 => quote! { short },
@@ -210,6 +213,21 @@ pub fn quote_raw_type_reference(schema: &Schema, types: &TypeMap) -> TokenStream
         Schema::I128 | Schema::U128 => {
             unreachable!("Invalid types should have already been handled")
         }
+    }
+}
+
+/// Generates the field definitions for the raw struct representation of an exported
+/// Rust type.
+pub fn raw_struct_fields(fields: &[(Ident, &Schema)], types: &TypeMap) -> TokenStream {
+    let field_name = fields.iter().map(|(name, _)| name);
+    let field_ty = fields
+        .iter()
+        .map(|(_, schema)| quote_raw_type_reference(schema, types));
+
+    quote! {
+        #(
+            internal #field_ty #field_name;
+        )*
     }
 }
 

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -2,7 +2,6 @@ use crate::generate::{binding, func::*, TypeMap};
 use cs_bindgen_shared::{schematic::Struct, BindingStyle, Method, NamedType, Schema};
 use proc_macro2::TokenStream;
 use quote::*;
-use syn::Ident;
 
 pub fn quote_drop_fn(name: &str, dll_name: &str) -> TokenStream {
     let binding_ident = format_ident!("__cs_bindgen_drop__{}", name);
@@ -25,7 +24,7 @@ pub fn quote_struct(export: &NamedType, _schema: &Struct) -> TokenStream {
 }
 
 /// Quotes the pointer type used for handles, i.e. `void*`.
-fn quote_handle_ptr() -> TokenStream {
+pub fn quote_handle_ptr() -> TokenStream {
     quote! { void* }
 }
 

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -1,5 +1,5 @@
 use crate::generate::{binding, func::*, TypeMap};
-use cs_bindgen_shared::{schematic::Struct, BindingStyle, Method, NamedType, Schema};
+use cs_bindgen_shared::{Method, NamedType, Schema};
 use proc_macro2::TokenStream;
 use quote::*;
 
@@ -15,20 +15,12 @@ pub fn quote_drop_fn(name: &str, dll_name: &str) -> TokenStream {
     }
 }
 
-pub fn quote_struct(export: &NamedType, _schema: &Struct) -> TokenStream {
-    match export.binding_style {
-        BindingStyle::Handle => quote_handle_type(export),
-
-        BindingStyle::Value => unimplemented!("Pass struct by value"),
-    }
-}
-
 /// Quotes the pointer type used for handles, i.e. `void*`.
 pub fn quote_handle_ptr() -> TokenStream {
     quote! { void* }
 }
 
-fn quote_handle_type(export: &NamedType) -> TokenStream {
+pub fn quote_handle_type(export: &NamedType) -> TokenStream {
     let ident = format_ident!("{}", &*export.name);
     let drop_fn = format_ident!("__cs_bindgen_drop__{}", &*export.name);
     let raw_repr = binding::raw_ident(&export.name);

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -1,4 +1,4 @@
-use crate::generate::{self, binding, quote_primitive_type, strukt, TypeMap};
+use crate::generate::{binding, quote_primitive_type, strukt, TypeMap};
 use cs_bindgen_shared::{schematic::Enum, schematic::Variant, BindingStyle, NamedType};
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
@@ -230,12 +230,7 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
             .map(|(index, field)| (strukt::field_ident(field.name, index), field.schema))
             .collect::<Vec<_>>();
 
-        let struct_fields = fields.iter().map(|(field_ident, schema)| {
-            let ty = generate::quote_cs_type(schema, types);
-            quote! {
-                #ty #field_ident
-            }
-        });
+        let struct_fields = strukt::struct_fields(&fields, types);
 
         let constructor_fields = fields.iter().map(|(field_ident, _)| {
             let from_raw_fn = binding::from_raw_fn_ident();
@@ -252,9 +247,7 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
             public struct #ident : #interface
             {
                 // Populate the fields of the variant struct.
-                #(
-                    public #struct_fields;
-                )*
+                #struct_fields
 
                 // Generate an internal constructor for creating an instance of the variant struct
                 // from its raw representation.

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -227,6 +227,16 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
         let fields = variant.fields().collect::<Vec<_>>();
 
         let struct_fields = strukt::struct_fields(&fields, types);
+
+        // Generate a basic constructor for the user-facing struct, but only if the
+        // struct has fields since we're not allowed to generate an explicit parameter-
+        // less constructor for structs in C#.
+        let struct_constructor = if !variant.is_empty() {
+            strukt::struct_constructor(&ident, &fields, types)
+        } else {
+            quote! {}
+        };
+
         let field_ident = fields
             .iter()
             .enumerate()
@@ -243,8 +253,8 @@ fn quote_complex_enum_binding(export: &NamedType, schema: &Enum, types: &TypeMap
             // Generate the C# struct for the variant.
             public struct #ident : #interface
             {
-                // Populate the fields of the variant struct.
                 #struct_fields
+                #struct_constructor
 
                 // Generate an internal constructor for creating an instance of the variant struct
                 // from its raw representation.

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -1,4 +1,4 @@
-use crate::generate::{binding, enumeration, quote_cs_type, TypeMap};
+use crate::generate::{binding, quote_cs_type, TypeMap};
 use cs_bindgen_shared::*;
 use heck::*;
 use proc_macro2::TokenStream;

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -45,7 +45,7 @@ pub fn quote_wrapper_fn<'a>(
     };
 
     let args = quote_args(inputs.clone(), types);
-    let body = quote_wrapper_body(binding, receiver, inputs, output, &ret, types);
+    let body = quote_wrapper_body(binding, receiver, inputs, output, &ret);
 
     quote! {
         public #static_ #return_ty #name(#( #args ),*)
@@ -77,7 +77,6 @@ pub fn quote_wrapper_body<'a>(
     args: impl Iterator<Item = (&'a str, &'a Schema)> + Clone,
     output: Option<&Schema>,
     ret: &Ident,
-    types: &TypeMap,
 ) -> TokenStream {
     // Build the list of arguments to the wrapper function and insert the receiver at
     // the beginning of the list of arguments if necessary.

--- a/cs-bindgen-cli/src/generate/strukt.rs
+++ b/cs-bindgen-cli/src/generate/strukt.rs
@@ -1,0 +1,62 @@
+use crate::generate::{self, binding, class, TypeMap};
+use cs_bindgen_shared::{
+    schematic::{Schema, Struct},
+    BindingStyle, NamedType,
+};
+use heck::CamelCase;
+use proc_macro2::TokenStream;
+use quote::*;
+use syn::Ident;
+
+pub fn quote_struct(export: &NamedType, schema: &Struct, types: &TypeMap) -> TokenStream {
+    if export.binding_style == BindingStyle::Handle {
+        return class::quote_handle_type(export);
+    }
+
+    let ident = format_ident!("{}", &*export.name);
+    let raw_ident = binding::raw_ident(&export.name);
+
+    let fields = schema
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| (field_ident(Some(&field.0), index), &field.1))
+        .collect::<Vec<_>>();
+
+    let struct_fields = struct_fields(&fields, types);
+    let raw_fields = binding::raw_struct_fields(&fields, types);
+
+    quote! {
+        public struct #ident
+        {
+            #struct_fields
+        }
+
+        internal struct #raw_ident
+        {
+            #raw_fields
+        }
+    }
+}
+
+/// Quotes the field declarations for the generated C# struct corresponding to an
+/// exported Rust type.
+pub fn struct_fields(fields: &[(Ident, &Schema)], types: &TypeMap) -> TokenStream {
+    let field_ident = fields.iter().map(|(ident, _)| ident);
+    let field_ty = fields
+        .iter()
+        .map(|(_, schema)| generate::quote_cs_type(schema, types));
+
+    quote! {
+        #(
+            public #field_ty #field_ident;
+        )*
+    }
+}
+
+/// Converts the specified field name into a C#-appropriate ident, or generates an
+/// ident based on the index of the field if the field is unnamed.
+pub fn field_ident(name: Option<&str>, index: usize) -> Ident {
+    name.map(|name| format_ident!("{}", name.to_camel_case()))
+        .unwrap_or_else(|| format_ident!("Element{}", index))
+}

--- a/cs-bindgen-cli/src/generate/strukt.rs
+++ b/cs-bindgen-cli/src/generate/strukt.rs
@@ -19,12 +19,14 @@ pub fn quote_struct(export: &NamedType, schema: &Struct, types: &TypeMap) -> Tok
     let fields = schema.fields().collect::<Vec<_>>();
 
     let struct_fields = struct_fields(&fields, types);
+    let constructor = struct_constructor(&ident, &fields, types);
     let raw_fields = binding::raw_struct_fields(&fields, types);
 
     quote! {
         public struct #ident
         {
             #struct_fields
+            #constructor
         }
 
         internal struct #raw_ident
@@ -53,9 +55,44 @@ pub fn struct_fields(fields: &[Field<'_>], types: &TypeMap) -> TokenStream {
     }
 }
 
+/// Quotes the basic constructor for the given type.
+///
+/// The basic constructor has a parameter for each field in the struct, and directly
+/// assigns each field.
+pub fn struct_constructor(ident: &Ident, fields: &[Field<'_>], types: &TypeMap) -> TokenStream {
+    let field_ident = fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| field_ident(field.name, index));
+
+    let arg_ident = fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| arg_ident(field.name, index))
+        .collect::<Vec<_>>();
+
+    let field_ty = fields
+        .iter()
+        .map(|field| generate::quote_cs_type(&field.schema, types));
+
+    quote! {
+        public #ident(#( #field_ty #arg_ident ),*)
+        {
+            #(
+                this.#field_ident = #arg_ident;
+            )*
+        }
+    }
+}
+
 /// Converts the specified field name into a C#-appropriate ident, or generates an
 /// ident based on the index of the field if the field is unnamed.
 pub fn field_ident(name: Option<&str>, index: usize) -> Ident {
     name.map(|name| format_ident!("{}", name.to_camel_case()))
         .unwrap_or_else(|| format_ident!("Element{}", index))
+}
+
+fn arg_ident(name: Option<&str>, index: usize) -> Ident {
+    name.map(|name| format_ident!("{}", name))
+        .unwrap_or_else(|| format_ident!("element_{}", index))
 }

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -156,7 +156,7 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
             .fields
             .iter()
             .enumerate()
-            .map(|(index, field)| field_ident(index, field));
+            .map(|(index, field)| value::field_ident(index, field));
 
         // Generate the destructuring expression for the fields of the variant.
         let destructure = match &variant.fields {
@@ -173,7 +173,7 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
             };
         }
 
-        let convert_fields = value::into_abi_fields(&variant.fields, &quote! {});
+        let convert_fields = value::into_abi_fields(&variant.fields, None);
 
         quote! {
             Self::#variant_ident #destructure => cs_bindgen::abi::RawEnum::new(
@@ -341,12 +341,4 @@ fn quote_describe_impl(item: &ItemEnum) -> syn::Result<TokenStream> {
             }
         }
     })
-}
-
-fn field_ident(index: usize, field: &Field) -> Ident {
-    field
-        .ident
-        .as_ref()
-        .map(Clone::clone)
-        .unwrap_or_else(|| format_ident!("element_{}", index))
 }

--- a/cs-bindgen-macro/src/func.rs
+++ b/cs-bindgen-macro/src/func.rs
@@ -2,27 +2,9 @@
 
 use proc_macro2::TokenStream;
 use quote::*;
-use std::fmt::Display;
 use syn::{punctuated::Punctuated, token::Comma, *};
 
 type FnInput = (Ident, Box<Type>);
-
-/// Generates an error if any generic parameters are present.
-///
-/// In general we can't support `#[cs_bindgen]` on generic items, any item that
-/// supports generic parameters needs to generate an error during parsing. This
-/// helper method can be used to check the `Generics` AST node that syn generates
-/// and will return an error if the node contains any generic parameters.
-pub fn reject_generics<M: Display>(generics: &Generics, message: M) -> syn::Result<()> {
-    let has_generics = generics.type_params().next().is_some()
-        || generics.lifetimes().next().is_some()
-        || generics.const_params().next().is_some();
-    if has_generics {
-        Err(Error::new_spanned(generics, message))
-    } else {
-        Ok(())
-    }
-}
 
 /// Processes the raw list of arguments into a format suitable for use in code
 /// generation.

--- a/cs-bindgen-macro/src/handle.rs
+++ b/cs-bindgen-macro/src/handle.rs
@@ -1,0 +1,78 @@
+//! Utilities for generating the bindings for types that should be marshaled as a handle.
+
+use proc_macro2::TokenStream;
+use quote::*;
+use syn::*;
+
+pub fn quote_type_as_handle(ident: &Ident) -> syn::Result<TokenStream> {
+    let name = ident.to_string();
+    let describe_ident = format_describe_ident!(ident);
+    let drop_ident = format_drop_ident!(ident);
+
+    Ok(quote! {
+        // Implement `Describe` for the exported type.
+        impl cs_bindgen::shared::schematic::Describe for #ident {
+            fn describe<E>(describer: E) -> Result<E::Ok, E::Error>
+            where
+                E: cs_bindgen::shared::schematic::Describer,
+            {
+                let describer = describer.describe_struct(cs_bindgen::shared::schematic::type_name!(#ident))?;
+                cs_bindgen::shared::schematic::DescribeStruct::end(describer)
+            }
+        }
+
+        // Implement `Abi` for the type and references to the type.
+
+        impl cs_bindgen::abi::Abi for #ident {
+            type Abi = *mut Self;
+
+            fn into_abi(self) -> Self::Abi {
+                std::boxed::Box::into_raw(std::boxed::Box::new(self))
+            }
+
+            unsafe fn from_abi(abi: Self::Abi) -> Self {
+                *std::boxed::Box::from_raw(abi)
+            }
+        }
+
+        impl<'a> cs_bindgen::abi::Abi for &'a #ident {
+            type Abi = Self;
+
+            fn into_abi(self) -> Self::Abi {
+                self
+            }
+
+            unsafe fn from_abi(abi: Self::Abi) -> Self {
+                abi
+            }
+        }
+
+        impl<'a> cs_bindgen::abi::Abi for &'a mut #ident {
+            type Abi = *mut #ident;
+
+            fn into_abi(self) -> Self::Abi {
+                self as *mut _
+            }
+
+            unsafe fn from_abi(abi: Self::Abi) -> Self {
+                &mut *abi
+            }
+        }
+
+        // Export a function that describes the exported type.
+        #[no_mangle]
+        pub unsafe extern "C" fn #describe_ident() -> std::boxed::Box<cs_bindgen::abi::RawString> {
+            let export = cs_bindgen::shared::NamedType {
+                name: #name.into(),
+                binding_style: cs_bindgen::shared::BindingStyle::Handle,
+                schema: cs_bindgen::shared::schematic::describe::<#ident>().expect("Failed to describe struct type"),
+            };
+
+            std::boxed::Box::new(cs_bindgen::shared::serialize_export(export).into())
+        }
+
+        // Export a function that can be used for dropping an instance of the type.
+        #[no_mangle]
+        pub unsafe extern "C" fn #drop_ident(_: <#ident as cs_bindgen::abi::Abi>::Abi) {}
+    })
+}

--- a/cs-bindgen-macro/src/handle.rs
+++ b/cs-bindgen-macro/src/handle.rs
@@ -10,17 +10,6 @@ pub fn quote_type_as_handle(ident: &Ident) -> syn::Result<TokenStream> {
     let describe_fn = describe_named_type(ident, BindingStyle::Handle);
 
     Ok(quote! {
-        // Implement `Describe` for the exported type.
-        impl cs_bindgen::shared::schematic::Describe for #ident {
-            fn describe<E>(describer: E) -> Result<E::Ok, E::Error>
-            where
-                E: cs_bindgen::shared::schematic::Describer,
-            {
-                let describer = describer.describe_struct(cs_bindgen::shared::schematic::type_name!(#ident))?;
-                cs_bindgen::shared::schematic::DescribeStruct::end(describer)
-            }
-        }
-
         // Implement `Abi` for the type and references to the type.
 
         impl cs_bindgen::abi::Abi for #ident {

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -1,8 +1,7 @@
-extern crate proc_macro;
-
-use crate::{enumeration::*, func::*};
+use crate::{enumeration::*, func::*, strukt::*};
 use proc_macro2::TokenStream;
 use quote::*;
+use std::fmt::Display;
 use syn::*;
 
 macro_rules! format_binding_ident {
@@ -25,6 +24,9 @@ macro_rules! format_drop_ident {
 
 mod enumeration;
 mod func;
+mod handle;
+mod strukt;
+mod value;
 
 #[proc_macro_attribute]
 pub fn cs_bindgen(
@@ -154,85 +156,6 @@ fn quote_fn_item(item: ItemFn) -> syn::Result<TokenStream> {
     Ok(quote! {
         #binding
         #describe
-    })
-}
-
-fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
-    reject_generics(
-        &item.generics,
-        "Generic structs are not supported with `#[cs_bindgen]`",
-    )?;
-
-    let ident = item.ident;
-    let name = ident.to_string();
-    let describe_ident = format_describe_ident!(ident);
-    let drop_ident = format_drop_ident!(ident);
-
-    Ok(quote! {
-        // Implement `Describe` for the exported type.
-        impl cs_bindgen::shared::schematic::Describe for #ident {
-            fn describe<E>(describer: E) -> Result<E::Ok, E::Error>
-            where
-                E: cs_bindgen::shared::schematic::Describer,
-            {
-                let describer = describer.describe_struct(cs_bindgen::shared::schematic::type_name!(#ident))?;
-                cs_bindgen::shared::schematic::DescribeStruct::end(describer)
-            }
-        }
-
-        // Implement `Abi` for the type and references to the type.
-
-        impl cs_bindgen::abi::Abi for #ident {
-            type Abi = *mut Self;
-
-            fn into_abi(self) -> Self::Abi {
-                std::boxed::Box::into_raw(std::boxed::Box::new(self))
-            }
-
-            unsafe fn from_abi(abi: Self::Abi) -> Self {
-                *std::boxed::Box::from_raw(abi)
-            }
-        }
-
-        impl<'a> cs_bindgen::abi::Abi for &'a #ident {
-            type Abi = Self;
-
-            fn into_abi(self) -> Self::Abi {
-                self
-            }
-
-            unsafe fn from_abi(abi: Self::Abi) -> Self {
-                abi
-            }
-        }
-
-        impl<'a> cs_bindgen::abi::Abi for &'a mut #ident {
-            type Abi = *mut #ident;
-
-            fn into_abi(self) -> Self::Abi {
-                self as *mut _
-            }
-
-            unsafe fn from_abi(abi: Self::Abi) -> Self {
-                &mut *abi
-            }
-        }
-
-        // Export a function that describes the exported type.
-        #[no_mangle]
-        pub unsafe extern "C" fn #describe_ident() -> std::boxed::Box<cs_bindgen::abi::RawString> {
-            let export = cs_bindgen::shared::NamedType {
-                name: #name.into(),
-                binding_style: cs_bindgen::shared::BindingStyle::Handle,
-                schema: cs_bindgen::shared::schematic::describe::<#ident>().expect("Failed to describe struct type"),
-            };
-
-            std::boxed::Box::new(cs_bindgen::shared::serialize_export(export).into())
-        }
-
-        // Export a function that can be used for dropping an instance of the type.
-        #[no_mangle]
-        pub unsafe extern "C" fn #drop_ident(_: <#ident as cs_bindgen::abi::Abi>::Abi) {}
     })
 }
 
@@ -436,4 +359,58 @@ fn quote_method_item(item: ImplItemMethod, self_ty: &Type) -> syn::Result<TokenS
         #binding
         #describe
     })
+}
+
+/// Returns `true` if any of the specified attributes are a `derive()` containing `Copy`.
+fn has_derive_copy(attributes: &[Attribute]) -> syn::Result<bool> {
+    // Get the `#[derive(..)]` attribute, or return `false` if none is present.
+    let attr = match attributes.iter().find(|attr| {
+        attr.path
+            .get_ident()
+            .map(|ident| ident == "derive")
+            .unwrap_or(false)
+    }) {
+        Some(attr) => attr.parse_meta()?,
+        None => return Ok(false),
+    };
+
+    let list = match attr {
+        Meta::List(list) => list,
+        _ => return Ok(false),
+    };
+
+    Ok(list.nested.into_iter().any(|nested| {
+        let nested = match nested {
+            NestedMeta::Meta(meta) => meta,
+            _ => return false,
+        };
+
+        let path = match nested {
+            Meta::Path(path) => path,
+            _ => return false,
+        };
+
+        // TODO: Handle the case where the user specified the full path for the trait, i.e.
+        // `std::marker::Copy`.
+        path.get_ident()
+            .map(|ident| ident == "Copy")
+            .unwrap_or(false)
+    }))
+}
+
+/// Generates an error if any generic parameters are present.
+///
+/// In general we can't support `#[cs_bindgen]` on generic items, any item that
+/// supports generic parameters needs to generate an error during parsing. This
+/// helper method can be used to check the `Generics` AST node that syn generates
+/// and will return an error if the node contains any generic parameters.
+fn reject_generics<M: Display>(generics: &Generics, message: M) -> syn::Result<()> {
+    let has_generics = generics.type_params().next().is_some()
+        || generics.lifetimes().next().is_some()
+        || generics.const_params().next().is_some();
+    if has_generics {
+        Err(Error::new_spanned(generics, message))
+    } else {
+        Ok(())
+    }
 }

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -1,4 +1,4 @@
-use crate::{handle, has_derive_copy, reject_generics, value};
+use crate::{describe_named_type, handle, has_derive_copy, reject_generics, value, BindingStyle};
 use proc_macro2::TokenStream;
 use quote::*;
 use syn::*;
@@ -16,8 +16,9 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
     if has_derive_copy(&item.attrs)? {
         handle::quote_type_as_handle(&ident)
     } else {
+        let abi_struct_ident = format_binding_ident!(ident);
         let abi_struct = value::quote_abi_struct(&abi_struct_ident, &item.fields);
-        let describe_fn = describe_named_type(&item.ident, BindingStyle::Value);
+        let describe_fn = describe_named_type(&ident, BindingStyle::Value);
 
         Ok(quote! {
             #abi_struct

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -1,0 +1,27 @@
+use crate::{handle, has_derive_copy, reject_generics, value};
+use proc_macro2::TokenStream;
+use quote::*;
+use syn::*;
+
+/// Generates the bindings for an exported struct.
+pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
+    reject_generics(
+        &item.generics,
+        "Generic structs are not supported with `#[cs_bindgen]`",
+    )?;
+
+    let ident = item.ident;
+
+    // Determine whether we should marshal the type as a handle or by value.
+    if has_derive_copy(&item.attrs)? {
+        handle::quote_type_as_handle(&ident)
+    } else {
+        let abi_struct = value::quote_abi_struct(&abi_struct_ident, &item.fields);
+        let describe_fn = describe_named_type(&item.ident, BindingStyle::Value);
+
+        Ok(quote! {
+            #abi_struct
+            #describe_fn
+        })
+    }
+}

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -17,7 +17,7 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
         let abi_struct_ident = format_binding_ident!(item.ident);
         let abi_struct = value::quote_abi_struct(&abi_struct_ident, &item.fields);
         let from_abi_fields = value::from_abi_fields(&item.fields, &quote! { abi });
-        let into_abi_fields = value::into_abi_fields(&item.fields, &quote! { self });
+        let into_abi_fields = value::into_abi_fields(&item.fields, Some(quote! { self }));
         let describe_fn = describe_named_type(&item.ident, BindingStyle::Value);
         let ident = item.ident;
 

--- a/cs-bindgen-macro/src/value.rs
+++ b/cs-bindgen-macro/src/value.rs
@@ -1,0 +1,34 @@
+use proc_macro2::TokenStream;
+use quote::*;
+use syn::*;
+
+pub fn quote_abi_struct(ident: &Ident, fields: &Fields) -> TokenStream {
+    // Extract the list of fields for the binding struct. The generated struct is the
+    // same for both struct-like and tuple-like variants, though in the latter case we
+    // have to manually generate names for the fields based on the index of the element.
+    let from_fields = fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            let field_ty = &field.ty;
+            let field_ident = field
+                .ident
+                .as_ref()
+                .map(Clone::clone)
+                .unwrap_or_else(|| format_ident!("element_{}", index));
+
+            quote! {
+                #field_ident: <#field_ty as cs_bindgen::abi::Abi>::Abi
+            }
+        })
+        .collect::<Vec<_>>();
+
+    quote! {
+        #[repr(C)]
+        #[derive(Clone, Copy)]
+        #[allow(bad_style)]
+        pub struct #ident {
+            #( #from_fields, )*
+        }
+    }
+}

--- a/cs-bindgen-macro/src/value.rs
+++ b/cs-bindgen-macro/src/value.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Literal, TokenStream};
+use proc_macro2::TokenStream;
 use quote::*;
 use syn::*;
 
@@ -11,10 +11,7 @@ pub fn quote_abi_struct(ident: &Ident, fields: &Fields) -> TokenStream {
         .enumerate()
         .map(|(index, field)| {
             let field_ty = &field.ty;
-            let field_ident = field
-                .ident
-                .clone()
-                .unwrap_or_else(|| format_ident!("element_{}", index));
+            let field_ident = field_ident(index, field);
 
             quote! {
                 #field_ident: <#field_ty as cs_bindgen::abi::Abi>::Abi
@@ -34,22 +31,42 @@ pub fn quote_abi_struct(ident: &Ident, fields: &Fields) -> TokenStream {
     }
 }
 
-pub fn into_abi_fields(fields: &Fields, input: &TokenStream) -> TokenStream {
-    let abi_field = fields.iter().enumerate().map(|(index, field)| {
-        field
-            .ident
-            .clone()
-            .unwrap_or_else(|| format_ident!("element_{}", index))
-    });
+/// Generates field conversion logic for an `Abi::into_abi` implementation.
+///
+/// Generates a comma-separated list of expressions to convert the specified fields
+/// into their FFI-compatible representations. For named fields, this will look like:
+///
+/// ```ignore
+/// field_name: cs_bindgen::abi::Abi::into_abi(prefix.field_name),
+/// ```
+///
+/// Unnamed fields will be the same but without the explicit field name:
+///
+/// ```ignore
+/// cs_bindgen::abi::Abi::into_abi(prefix.field_name),
+/// ```
+///
+/// Returns an empty token stream if `fields` is empty.
+///
+/// `input` is the expression for the value being converted. For example, if
+/// `foo.field_name` would be the correct expression to access the field, then
+/// `input` should be `foo`. If `input` is `Some`, then a `.` token will be inserted
+/// before the name of the field, otherwise the `.` will be omitted.
+pub fn into_abi_fields(fields: &Fields, input: Option<TokenStream>) -> TokenStream {
+    let abi_field = fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| field_ident(index, field));
+
+    let field_prefix = match input {
+        Some(input) => quote! { #input. },
+        None => quote! {},
+    };
 
     let conversion = fields.iter().enumerate().map(|(index, field)| {
-        let input_field = field
-            .ident
-            .as_ref()
-            .map(|ident| ident.to_token_stream())
-            .unwrap_or_else(|| Literal::usize_unsuffixed(index).into_token_stream());
+        let input_field = field_ident(index, field);
         quote! {
-            cs_bindgen::abi::Abi::into_abi(#input.#input_field)
+            cs_bindgen::abi::Abi::into_abi(#field_prefix #input_field)
         }
     });
 
@@ -67,11 +84,7 @@ pub fn from_abi_fields(fields: &Fields, input: &TokenStream) -> TokenStream {
     });
 
     let conversion = fields.iter().enumerate().map(|(index, field)| {
-        let field_ident = field
-            .ident
-            .clone()
-            .unwrap_or_else(|| format_ident!("element_{}", index));
-
+        let field_ident = field_ident(index, field);
         quote! { cs_bindgen::abi::Abi::from_abi(#input.#field_ident) }
     });
 
@@ -80,4 +93,16 @@ pub fn from_abi_fields(fields: &Fields, input: &TokenStream) -> TokenStream {
             #assignment #conversion,
         )*
     }
+}
+
+/// Returns the ident for a field, or generates one if the field is unnamed.
+///
+/// This ensures a consistent naming convention when generating struct
+/// representations of enums. Unnamed fields will be named `element_{index}`.
+pub fn field_ident(index: usize, field: &Field) -> Ident {
+    field
+        .ident
+        .as_ref()
+        .map(Clone::clone)
+        .unwrap_or_else(|| format_ident!("element_{}", index))
 }

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "e707fca" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "24f5437" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "24f5437" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "f8e6196" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/integration-tests/TestRunner/ValueTypes.cs
+++ b/integration-tests/TestRunner/ValueTypes.cs
@@ -9,7 +9,12 @@ namespace TestRunner
         [Fact]
         public void MahjongTile()
         {
-            var tile = new SimpleTile(Suit.Bamboo, 1);
+            // var tile = new SimpleTile(Suit.Bamboo, 1);
+            var tile = new SimpleTile
+            {
+                Suit = Suit.Bamboo,
+                Value = 1,
+            };
             Assert.Equal(Suit.Bamboo, tile.Suit);
             Assert.Equal(1, tile.Value);
         }

--- a/integration-tests/TestRunner/ValueTypes.cs
+++ b/integration-tests/TestRunner/ValueTypes.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Xunit;
 
 namespace TestRunner
@@ -9,6 +7,7 @@ namespace TestRunner
         [Fact]
         public void MahjongTile()
         {
+            // TODO: Generate a constructor for structs.
             // var tile = new SimpleTile(Suit.Bamboo, 1);
             var tile = new SimpleTile
             {

--- a/integration-tests/TestRunner/ValueTypes.cs
+++ b/integration-tests/TestRunner/ValueTypes.cs
@@ -10,6 +10,11 @@ namespace TestRunner
             var tile = new SimpleTile(Suit.Bamboo, 1);
             Assert.Equal(Suit.Bamboo, tile.Suit);
             Assert.Equal(1, tile.Value);
+
+            var result = IntegrationTests.RoundtripSimpleTile(tile);
+            Assert.Equal(tile, result);
+            Assert.Equal(tile.Suit, result.Suit);
+            Assert.Equal(tile.Value, result.Value);
         }
     }
 }

--- a/integration-tests/TestRunner/ValueTypes.cs
+++ b/integration-tests/TestRunner/ValueTypes.cs
@@ -7,13 +7,7 @@ namespace TestRunner
         [Fact]
         public void MahjongTile()
         {
-            // TODO: Generate a constructor for structs.
-            // var tile = new SimpleTile(Suit.Bamboo, 1);
-            var tile = new SimpleTile
-            {
-                Suit = Suit.Bamboo,
-                Value = 1,
-            };
+            var tile = new SimpleTile(Suit.Bamboo, 1);
             Assert.Equal(Suit.Bamboo, tile.Suit);
             Assert.Equal(1, tile.Value);
         }

--- a/integration-tests/TestRunner/ValueTypes.cs
+++ b/integration-tests/TestRunner/ValueTypes.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace TestRunner
+{
+    public class ValueTypes
+    {
+        [Fact]
+        public void MahjongTile()
+        {
+            var tile = new SimpleTile(Suit.Bamboo, 1);
+            Assert.Equal(Suit.Bamboo, tile.Suit);
+            Assert.Equal(1, tile.Value);
+        }
+    }
+}

--- a/integration-tests/src/copy_types.rs
+++ b/integration-tests/src/copy_types.rs
@@ -16,3 +16,8 @@ pub enum Suit {
     Circles,
     Man,
 }
+
+#[cs_bindgen]
+pub fn roundtrip_simple_tile(tile: SimpleTile) -> SimpleTile {
+    tile
+}

--- a/integration-tests/src/copy_types.rs
+++ b/integration-tests/src/copy_types.rs
@@ -1,0 +1,18 @@
+//! Example types that derive `Copy` and should therefore be marshaled by value.
+
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SimpleTile {
+    pub suit: Suit,
+    pub value: u8,
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Suit {
+    Bamboo,
+    Circles,
+    Man,
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::data_enum::DataEnum;
 use cs_bindgen::prelude::*;
 
+pub mod copy_types;
 pub mod data_enum;
 pub mod name_collision;
 pub mod simple_enum;


### PR DESCRIPTION
Support for marshaling Rust types by value was added in #40 to enable passing data-carrying enums in a meaningful way. This PR extends that functionality to structs as well, with structs that derive `Copy` being marshaled by value by default. In doing so, I was also able to simplify and generalize a lot of the logic that was previously specific to generating code for data-carrying enums.