### PR TITLE
Add support for exporting tuple structs

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -294,7 +294,7 @@ fn quote_cs_type(schema: &Schema, types: &TypeMap) -> TokenStream {
         | Schema::UnitStruct(_)
         | Schema::NewtypeStruct(_) => named_type_reference(schema.type_name().unwrap(), types),
 
-        // TODO: Add support for passing user-defined types out from Rust.
+        // TODO: Add support for collection types.
         Schema::Option(_) | Schema::Seq(_) | Schema::Tuple(_) | Schema::Map { .. } => {
             todo!("Generate argument binding")
         }

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -79,7 +79,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 )),
 
                 Schema::Enum(schema) => {
-                    binding_items.push(quote_enum_binding(export, schema, &types))
+                    binding_items.push(quote_enum(export, schema, &types))
                 }
 
                 _ => {

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -237,6 +237,28 @@ fn quote_primitive_type(ty: Primitive) -> TokenStream {
 
 /// Generates the idiomatic C# type corresponding to the given type schema.
 fn quote_cs_type(schema: &Schema, types: &TypeMap) -> TokenStream {
+    // Create a helper closure for generating references to named types in a uniform way.
+    let named_type_reference = |type_name, types: &TypeMap| {
+        let export = types
+            .get(type_name)
+            .unwrap_or_else(|| panic!("Could not resolve type reference: {:?}", type_name));
+
+        // NOTE: Enums are a special case since the user-facing type for a data-carrying
+        // enum is an interface, and therefore has a different naming convention from
+        // Rust structs.
+        let ident = if let Schema::Enum(schema) = &schema {
+            enumeration::quote_type_reference(export, schema)
+        } else {
+            format_ident!("{}", &*export.name).into_token_stream()
+        };
+
+        // TODO: Take into account things like custom namespaces or renaming the type, once
+        // those are supported. For now, we manually prefix references to user-defined types
+        // with `global::` in order to avoid name collisions. Once we support custom
+        // namespaces, we'll want to use the correct namespace name instead.
+        quote! { global::#ident }
+    };
+
     match schema {
         // NOTE: This is only valid in a return position, it's not valid to have a `void`
         // argument. An earlier validation pass has already rejected any such cases so we
@@ -263,39 +285,19 @@ fn quote_cs_type(schema: &Schema, types: &TypeMap) -> TokenStream {
 
         Schema::Char => todo!("Support passing single chars"),
 
-        Schema::Struct(schema) => {
-            let export = types
-                .get(&schema.name)
-                .expect("Failed to look up referenced type");
-
-            let ident = format_ident!("{}", &*export.name).into_token_stream();
-
-            // TODO: Take into account things like custom namespaces or renaming the type, once
-            // those are supported. For now, we manually prefix references to user-defined types
-            // with `global::` in order to avoid name collisions. Once we support custom
-            // namespaces, we'll want to use the correct namespace name instead.
-            quote! { global::#ident }
-        }
-
-        Schema::Enum(schema) => {
-            let export = types
-                .get(&schema.name)
-                .expect("Failed to look up referenced type");
-            let ident = enumeration::quote_type_reference(&export, schema);
-
-            // TODO: Once custom namespaces are supported, use the appropriate namespace instead
-            // of `global::`.
-            quote! { global::#ident }
-        }
+        // NOTE: The unwrap here is valid because all of the struct-like variants are
+        // guaranteed to have a type name. If this panic, that indicates a bug in the
+        // schematic crate.
+        Schema::Enum(_)
+        | Schema::Struct(_)
+        | Schema::TupleStruct(_)
+        | Schema::UnitStruct(_)
+        | Schema::NewtypeStruct(_) => named_type_reference(schema.type_name().unwrap(), types),
 
         // TODO: Add support for passing user-defined types out from Rust.
-        Schema::UnitStruct(_)
-        | Schema::NewtypeStruct(_)
-        | Schema::TupleStruct(_)
-        | Schema::Option(_)
-        | Schema::Seq(_)
-        | Schema::Tuple(_)
-        | Schema::Map { .. } => todo!("Generate argument binding"),
+        Schema::Option(_) | Schema::Seq(_) | Schema::Tuple(_) | Schema::Map { .. } => {
+            todo!("Generate argument binding")
+        }
 
         Schema::I128 | Schema::U128 => {
             unreachable!("Invalid argument types should have already been rejected");

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -1,8 +1,14 @@
 //! Utilities for generating the raw bindings to exported Rust items.
 //!
+//! This module provides the code generation for the C# declarations that bind to
+//! Rust functions that are exported from the built dylib. Note that this
+//! specifically refers to the *generated* functions, not the user defined
+//! functions. This module also provides utilities for referencing the raw function
+//! bindings in other parts of the code generation.
+//!
 //! In C#, the raw binding to an exported Rust function is a `static extern`
 //! function, using the `[DllImport]` attribute to load the corresponding function
-//! from the Rust dylib. This module provides
+//! from the Rust dylib.
 
 use crate::generate::{class, strukt, TypeMap};
 use cs_bindgen_shared::{

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -6,7 +6,7 @@
 
 use crate::generate::{class, enumeration, quote_cs_type, strukt, TypeMap};
 use cs_bindgen_shared::{
-    schematic::{Field, Schema},
+    schematic::{Field, Schema, TypeName},
     BindingStyle, Export,
 };
 use proc_macro2::TokenStream;
@@ -174,6 +174,13 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
 // it once we support custom namespaces, since we'll need to look up the export
 // information to determine the fully-qualified name for the type.
 pub fn quote_raw_type_reference(schema: &Schema, _types: &TypeMap) -> TokenStream {
+    fn named_type_raw_reference(type_name: &TypeName) -> TokenStream {
+        let ident = raw_ident(&type_name.name);
+        quote! {
+            global::#ident
+        }
+    }
+
     match schema {
         Schema::I8 => quote! { sbyte },
         Schema::I16 => quote! { short },
@@ -189,28 +196,19 @@ pub fn quote_raw_type_reference(schema: &Schema, _types: &TypeMap) -> TokenStrea
         Schema::Char => quote! { uint },
         Schema::String => quote! { RustOwnedString },
 
-        Schema::Enum(schema) => {
-            let ident = raw_ident(&schema.name.name);
-            quote! {
-                global::#ident
-            }
-        }
-
-        Schema::Struct(schema) => {
-            let ident = raw_ident(&schema.name.name);
-            quote! {
-                global::#ident
-            }
-        }
-
-        // TODO: Add support for more user-defined types.
-        Schema::UnitStruct(_)
+        // NOTE: The unwrap here is valid because all of the struct-like variants are
+        // guaranteed to have a type name. If this panic, that indicates a bug in the
+        // schematic crate.
+        Schema::Enum(_)
+        | Schema::Struct(_)
+        | Schema::UnitStruct(_)
         | Schema::NewtypeStruct(_)
-        | Schema::TupleStruct(_)
-        | Schema::Option(_)
-        | Schema::Seq(_)
-        | Schema::Tuple(_)
-        | Schema::Map { .. } => todo!("Generate argument binding"),
+        | Schema::TupleStruct(_) => named_type_raw_reference(schema.type_name().unwrap()),
+
+        // TODO: Add support for collection types.
+        Schema::Option(_) | Schema::Seq(_) | Schema::Tuple(_) | Schema::Map { .. } => {
+            todo!("Generate argument binding")
+        }
 
         Schema::Unit => quote! { byte },
 

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -25,6 +25,21 @@ pub fn quote_handle_type(export: &NamedType) -> TokenStream {
     let drop_fn = format_ident!("__cs_bindgen_drop__{}", &*export.name);
     let raw_repr = binding::raw_ident(&export.name);
 
+    let from_raw = binding::from_raw_fn_ident();
+    let into_raw = binding::into_raw_fn_ident();
+
+    let raw_conversions = binding::wrap_bindings(quote! {
+        internal static #ident #from_raw(#raw_repr raw)
+        {
+            return new #ident(raw);
+        }
+
+        internal static #raw_repr #into_raw(#ident self)
+        {
+            return new #raw_repr(self);
+        }
+    });
+
     quote! {
         public unsafe partial class #ident : IDisposable
         {
@@ -56,6 +71,8 @@ pub fn quote_handle_type(export: &NamedType) -> TokenStream {
                 this.Handle = orig._handle;
             }
         }
+
+        #raw_conversions
     }
 }
 

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -1,3 +1,5 @@
+//! Code generation for exported named types that are marshaled as handles.
+
 use crate::generate::{binding, func::*, TypeMap};
 use cs_bindgen_shared::{Method, NamedType, Schema};
 use proc_macro2::TokenStream;

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -3,8 +3,8 @@ use cs_bindgen_shared::{Method, NamedType, Schema};
 use proc_macro2::TokenStream;
 use quote::*;
 
-pub fn quote_drop_fn(name: &str, dll_name: &str) -> TokenStream {
-    let binding_ident = format_ident!("__cs_bindgen_drop__{}", name);
+pub fn quote_drop_fn(export: &NamedType, dll_name: &str) -> TokenStream {
+    let binding_ident = format_ident!("__cs_bindgen_drop__{}", &*export.name);
     let entry_point = binding_ident.to_string();
     quote! {
         [DllImport(

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -84,6 +84,7 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
         Schema::Struct(struct_) => &struct_.name,
         _ => todo!("Support methods for other named types"),
     };
+
     let class_ident = format_ident!("{}", &*class_name.name);
 
     // Use a heuristic to determine if the method should be treated as a constructor.

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -1,3 +1,5 @@
+//! Code generation for exported functions and methods.
+
 use crate::generate::{binding, quote_cs_type, TypeMap};
 use cs_bindgen_shared::*;
 use heck::*;

--- a/cs-bindgen-cli/src/generate/strukt.rs
+++ b/cs-bindgen-cli/src/generate/strukt.rs
@@ -1,3 +1,5 @@
+//! Code generation for exported struct types.
+
 use crate::generate::{self, binding, class, TypeMap};
 use cs_bindgen_shared::{
     schematic::{Field, StructLike},

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -156,7 +156,7 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
             .fields
             .iter()
             .enumerate()
-            .map(|(index, field)| value::field_ident(index, field));
+            .map(|(index, field)| value::raw_field_ident(index, field));
 
         // Generate the destructuring expression for the fields of the variant.
         let destructure = match &variant.fields {

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -173,7 +173,9 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
             };
         }
 
-        let convert_fields = value::into_abi_fields(&variant.fields, None);
+        let convert_fields = value::into_abi_fields(&variant.fields, |index, field| {
+            value::raw_field_ident(index, field).into_token_stream()
+        });
 
         quote! {
             Self::#variant_ident #destructure => cs_bindgen::abi::RawEnum::new(

--- a/cs-bindgen-macro/src/value.rs
+++ b/cs-bindgen-macro/src/value.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Literal, TokenStream};
+use proc_macro2::TokenStream;
 use quote::*;
 use syn::*;
 
@@ -48,25 +48,25 @@ pub fn quote_abi_struct(ident: &Ident, fields: &Fields) -> TokenStream {
 ///
 /// Returns an empty token stream if `fields` is empty.
 ///
-/// `input` is the expression for the value being converted. For example, if
-/// `foo.field_name` would be the correct expression to access the field, then
-/// `input` should be `foo`. If `input` is `Some`, then a `.` token will be inserted
-/// before the name of the field, otherwise the `.` will be omitted.
-pub fn into_abi_fields(fields: &Fields, input: Option<TokenStream>) -> TokenStream {
+/// # Field Accessors
+///
+/// `field_accessor` is a closure that should generate the appropriate expression
+/// for accessing the field in the current context. The returned value will be
+/// treated as the expression that is passed into `Abi::into_abi` in the generated
+/// code.
+pub fn into_abi_fields(
+    fields: &Fields,
+    field_accessor: impl Fn(usize, &Field) -> TokenStream,
+) -> TokenStream {
     let abi_field = fields
         .iter()
         .enumerate()
         .map(|(index, field)| raw_field_ident(index, field));
 
-    let field_prefix = match input {
-        Some(input) => quote! { #input. },
-        None => quote! {},
-    };
-
     let conversion = fields.iter().enumerate().map(|(index, field)| {
         let input_field = field_accessor(index, field);
         quote! {
-            cs_bindgen::abi::Abi::into_abi(#field_prefix #input_field)
+            cs_bindgen::abi::Abi::into_abi(#input_field)
         }
     });
 
@@ -93,18 +93,6 @@ pub fn from_abi_fields(fields: &Fields, input: &TokenStream) -> TokenStream {
             #assignment #conversion,
         )*
     }
-}
-
-/// Returns the appropriate accessor expression for the specified field.
-///
-/// For named fields, this will return the field name, e.g. `foo`. For unnamed
-/// fields, this will return the field index, e.g. `0`.
-pub fn field_accessor(index: usize, field: &Field) -> TokenStream {
-    field
-        .ident
-        .as_ref()
-        .map(|ident| ident.into_token_stream())
-        .unwrap_or_else(|| Literal::usize_unsuffixed(index).into_token_stream())
 }
 
 /// Returns the ident of the field in a raw binding struct corresponding to the

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "f8e6196" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "a757089" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen/tests/derive.rs
+++ b/cs-bindgen/tests/derive.rs
@@ -13,3 +13,26 @@ pub struct TupleStruct(u32, String, bool);
 #[cs_bindgen]
 #[derive(Clone, Copy)]
 pub struct CopyTupleStruct(u32, u8, bool);
+
+#[cs_bindgen]
+pub enum CLikeEnum {
+    Foo,
+    Bar,
+    Baz,
+}
+
+#[cs_bindgen]
+#[derive(Clone, Copy)]
+pub enum CLikeEnumCopy {
+    Foo,
+    Bar,
+    Baz,
+}
+
+#[cs_bindgen]
+pub enum DataEnum {
+    Foo,
+    Bar(u32),
+    Baz(u32, u8),
+    Quux { one: u32, two: u8 },
+}

--- a/cs-bindgen/tests/derive.rs
+++ b/cs-bindgen/tests/derive.rs
@@ -36,3 +36,37 @@ pub enum DataEnum {
     Baz(u32, u8),
     Quux { one: u32, two: u8 },
 }
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct StructWithMethods {
+    pub foo: String,
+}
+
+#[cs_bindgen]
+impl StructWithMethods {
+    pub fn new(foo: String) -> StructWithMethods {
+        Self { foo }
+    }
+
+    pub fn foo(&self) -> String {
+        self.foo.clone()
+    }
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct AnotherStructWithMethods {
+    pub foo: String,
+}
+
+#[cs_bindgen]
+impl AnotherStructWithMethods {
+    pub fn new(foo: String) -> AnotherStructWithMethods {
+        Self { foo }
+    }
+
+    pub fn foo(&self) -> String {
+        self.foo.clone()
+    }
+}

--- a/cs-bindgen/tests/derive.rs
+++ b/cs-bindgen/tests/derive.rs
@@ -1,0 +1,15 @@
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+pub struct NewtypeStruct(u32);
+
+#[cs_bindgen]
+#[derive(Clone, Copy)]
+pub struct CopyNewtypeStruct(u32);
+
+#[cs_bindgen]
+pub struct TupleStruct(u32, String, bool);
+
+#[cs_bindgen]
+#[derive(Clone, Copy)]
+pub struct CopyTupleStruct(u32, u8, bool);

--- a/integration-tests/TestRunner/Structs.cs
+++ b/integration-tests/TestRunner/Structs.cs
@@ -7,14 +7,25 @@ namespace TestRunner
         [Fact]
         public void CopyTupleStruct_RoundTrip()
         {
-            var tuple = new CopyTupleStruct(1, 2);
-            Assert.Equal(1, tuple.Element0);
-            Assert.Equal(2, tuple.Element1);
+            var original = new CopyTupleStruct(1, 2);
+            Assert.Equal(1, original.Element0);
+            Assert.Equal(2, original.Element1);
 
-            var result = IntegrationTests.CopyTupleStructRoundTrip(tuple);
-            Assert.Equal(tuple, result);
-            Assert.Equal(tuple.Element0, result.Element0);
-            Assert.Equal(tuple.Element1, result.Element1);
+            var result = IntegrationTests.RoundTripCopyTupleStruct(original);
+            Assert.Equal(original, result);
+            Assert.Equal(original.Element0, result.Element0);
+            Assert.Equal(original.Element1, result.Element1);
+        }
+
+        [Fact]
+        public void CopyNewtypeStruct_RoundTrip()
+        {
+            var original = new CopyNewtypeStruct(123);
+            Assert.Equal(123, original.Element0);
+
+            var result = IntegrationTests.RoundTripCopyNewtypeStruct(original);
+            Assert.Equal(original, result);
+            Assert.Equal(original.Element0, result.Element0);
         }
     }
 }

--- a/integration-tests/TestRunner/Structs.cs
+++ b/integration-tests/TestRunner/Structs.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace TestRunner
+{
+    public class Structs
+    {
+        [Fact]
+        public void CopyTupleStruct_RoundTrip()
+        {
+            var tuple = new CopyTupleStruct(1, 2);
+            Assert.Equal(1, tuple.Element0);
+            Assert.Equal(2, tuple.Element1);
+
+            var result = IntegrationTests.CopyTupleStructRoundTrip(tuple);
+            Assert.Equal(tuple, result);
+            Assert.Equal(tuple.Element0, result.Element0);
+            Assert.Equal(tuple.Element1, result.Element1);
+        }
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,10 +1,10 @@
-use crate::data_enum::DataEnum;
 use cs_bindgen::prelude::*;
 
 pub mod copy_types;
 pub mod data_enum;
 pub mod name_collision;
 pub mod simple_enum;
+pub mod structs;
 
 // Re-export core cs_bindgen functionality. Required in order for the generated Wasm module.
 cs_bindgen::export!();
@@ -30,79 +30,6 @@ pub fn is_seven(value: i32) -> bool {
 }
 
 #[cs_bindgen]
-#[derive(Debug, Clone)]
-pub struct PersonInfo {
-    name: String,
-    age: i32,
-    address: Address,
-}
-
-#[cs_bindgen]
-impl PersonInfo {
-    // TODO: Change the return type back to `Self` once that's supported.
-    pub fn new(name: String, age: i32) -> PersonInfo {
-        Self {
-            name,
-            age,
-            address: Address {
-                street_number: 123,
-                street: "Cool Kids Lane".into(),
-            },
-        }
-    }
-
-    // TODO: Change this to return `&str` once that's supported.
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    pub fn age(&self) -> i32 {
-        self.age
-    }
-
-    pub fn set_age(&mut self, age: i32) {
-        self.age = age;
-    }
-
-    pub fn static_function() -> i32 {
-        7
-    }
-
-    pub fn address(&self) -> Address {
-        self.address.clone()
-    }
-
-    pub fn is_minor(&self) -> bool {
-        self.age < 21
-    }
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone)]
-pub struct Address {
-    street_number: u32,
-    street: String,
-}
-
-#[cs_bindgen]
-impl Address {
-    pub fn street_number(&self) -> u32 {
-        self.street_number
-    }
-
-    // TODO: Change this to return `&str` once that's supported.
-    pub fn street_name(&self) -> String {
-        self.street.clone()
-    }
-}
-
-#[cs_bindgen]
 pub fn void_return(test: i32) {
     println!("{}", test);
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone)]
-pub struct WrapperType {
-    pub value: DataEnum,
 }

--- a/integration-tests/src/structs.rs
+++ b/integration-tests/src/structs.rs
@@ -78,3 +78,12 @@ impl Address {
 pub struct WrapperType {
     pub value: DataEnum,
 }
+
+// Test tuple-like structs, including newtype structs (tuple-like structs with a single element).
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub struct NewtypeStruct(u32);
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct TupleStruct(String, String);

--- a/integration-tests/src/structs.rs
+++ b/integration-tests/src/structs.rs
@@ -87,3 +87,20 @@ pub struct NewtypeStruct(u32);
 #[cs_bindgen]
 #[derive(Debug, Clone)]
 pub struct TupleStruct(String, String);
+
+// TODO: Support methods on tuple structs.
+// #[cs_bindgen]
+// impl TupleStruct {
+//     pub fn new(first: String, second: String) -> TupleStruct {
+//         Self(first, second)
+//     }
+// }
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub struct CopyTupleStruct(i32, i32);
+
+#[cs_bindgen]
+pub fn copy_tuple_struct_round_trip(value: CopyTupleStruct) -> CopyTupleStruct {
+    value
+}

--- a/integration-tests/src/structs.rs
+++ b/integration-tests/src/structs.rs
@@ -101,6 +101,15 @@ pub struct TupleStruct(String, String);
 pub struct CopyTupleStruct(i32, i32);
 
 #[cs_bindgen]
-pub fn copy_tuple_struct_round_trip(value: CopyTupleStruct) -> CopyTupleStruct {
+pub fn round_trip_copy_tuple_struct(value: CopyTupleStruct) -> CopyTupleStruct {
+    value
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub struct CopyNewtypeStruct(i32);
+
+#[cs_bindgen]
+pub fn round_trip_copy_newtype_struct(value: CopyNewtypeStruct) -> CopyNewtypeStruct {
     value
 }

--- a/integration-tests/src/structs.rs
+++ b/integration-tests/src/structs.rs
@@ -1,0 +1,80 @@
+use crate::data_enum::DataEnum;
+use cs_bindgen::prelude::*;
+
+// Basic struct with named parameters. Includes both primitive type fields and
+// another struct field.
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct PersonInfo {
+    name: String,
+    age: i32,
+    address: Address,
+}
+
+// Export methods associated with an exported struct. Includes a constructor,
+// getters, setters, and methods that operate on the internal state of the object.
+#[cs_bindgen]
+impl PersonInfo {
+    // TODO: Change the return type back to `Self` once that's supported.
+    pub fn new(name: String, age: i32) -> PersonInfo {
+        Self {
+            name,
+            age,
+            address: Address {
+                street_number: 123,
+                street: "Cool Kids Lane".into(),
+            },
+        }
+    }
+
+    // TODO: Change this to return `&str` once that's supported.
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn age(&self) -> i32 {
+        self.age
+    }
+
+    pub fn set_age(&mut self, age: i32) {
+        self.age = age;
+    }
+
+    pub fn static_function() -> i32 {
+        7
+    }
+
+    pub fn address(&self) -> Address {
+        self.address.clone()
+    }
+
+    pub fn is_minor(&self) -> bool {
+        self.age < 21
+    }
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct Address {
+    street_number: u32,
+    street: String,
+}
+
+#[cs_bindgen]
+impl Address {
+    pub fn street_number(&self) -> u32 {
+        self.street_number
+    }
+
+    // TODO: Change this to return `&str` once that's supported.
+    pub fn street_name(&self) -> String {
+        self.street.clone()
+    }
+}
+
+// Test a struct with a field that is a data-carrying enum.
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct WrapperType {
+    pub value: DataEnum,
+}


### PR DESCRIPTION
Generalize support for structs such that all styles of struct can be handled in a more uniform way. This allows us to export tuple structs by handle or by value the same way for all styles of struct. Exporting methods for tuple-like structs is still not supported, though.