### PR TITLE
Use out parameters to improve overload resolution for type conversion

### DIFF
--- a/cs-bindgen-cli/Cargo.toml
+++ b/cs-bindgen-cli/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 cs-bindgen-shared = { version = "0.1.0", path = "../cs-bindgen-shared" }
 failure = "0.1.6"
 heck = "0.3.1"
+lazy_static = "1.4.0"
 parity-wasm = "0.41.0"
 proc-macro2 = "1.0.8"
 quote = "1.0.3"

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -125,7 +125,7 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
 // NOTE: We're not currently using the type map parameter, but we'll eventually need
 // it once we support custom namespaces, since we'll need to look up the export
 // information to determine the fully-qualified name for the type.
-pub fn quote_raw_type_reference(schema: &Schema, _types: &TypeMap) -> TokenStream {
+pub fn quote_raw_type_reference(schema: &Schema, types: &TypeMap) -> TokenStream {
     fn named_type_raw_reference(type_name: &TypeName) -> TokenStream {
         let ident = raw_ident(&type_name.name);
         quote! {
@@ -168,24 +168,46 @@ pub fn quote_raw_type_reference(schema: &Schema, _types: &TypeMap) -> TokenStrea
 
         Schema::Str => quote! { RawSlice },
 
-        // For data-carrying enums, the raw representation will be a struct named according
-        // to the naming convention for raw structs. For C-Like enums the raw representation
-        // will be the integer type of the discriminant.
         Schema::Enum(schema) => {
-            if schema.has_data() {
+            let export = types
+                .get(&schema.name)
+                .unwrap_or_else(|| panic!("No export found for named type {:?}", &schema.name));
+
+            // There are three possible raw representations for an exported enum:
+            //
+            // * Enums that are marshalled as handles are represented as the raw handle pointer
+            //   type (`void*`).
+            // * Data-carrying enums have an associate struct that represents its raw type.
+            // * C-like enums are marshalled directly as an integer value.
+            if export.binding_style == BindingStyle::Handle {
+                class::quote_handle_ptr()
+            } else if schema.has_data() {
                 named_type_raw_reference(&schema.name)
             } else {
                 enumeration::quote_discriminant_type(schema)
             }
         }
 
-        // NOTE: The `unwrap` here is valid because all of the struct-like variants are
-        // guaranteed to have a type name. If this panic, that indicates a bug in the
-        // schematic crate.
         Schema::Struct(_)
         | Schema::UnitStruct(_)
         | Schema::NewtypeStruct(_)
-        | Schema::TupleStruct(_) => named_type_raw_reference(schema.type_name().unwrap()),
+        | Schema::TupleStruct(_) => {
+            // NOTE: The `unwrap` here is valid because all of the struct-like variants are
+            // guaranteed to have a type name. If this panic, that indicates a bug in the
+            // schematic crate.
+            let type_name = schema.type_name().unwrap();
+
+            let export = types
+                .get(type_name)
+                .unwrap_or_else(|| panic!("No export found for named type {:?}", type_name));
+
+            // Determine the raw representation based on the marshaling style.
+            if export.binding_style == BindingStyle::Handle {
+                class::quote_handle_ptr()
+            } else {
+                named_type_raw_reference(type_name)
+            }
+        }
 
         Schema::Array(_) => todo!("Support passing fixed-size arrays"),
 

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -1,6 +1,6 @@
 //! Code generation for exported named types that are marshaled as handles.
 
-use crate::generate::{binding, func::*, TypeMap};
+use crate::generate::{binding, func, TypeMap};
 use cs_bindgen_shared::{Method, NamedType, Schema};
 use proc_macro2::TokenStream;
 use quote::*;
@@ -49,7 +49,7 @@ pub fn quote_handle_type(export: &NamedType) -> TokenStream {
 
             internal #ident(#raw_repr raw)
             {
-                _handle = raw.Handle;
+                _handle = raw;
             }
 
             public void Dispose()
@@ -62,23 +62,11 @@ pub fn quote_handle_type(export: &NamedType) -> TokenStream {
             }
         }
 
-        [StructLayout(LayoutKind.Explicit)]
-        internal unsafe struct #raw_repr
-        {
-            [FieldOffset(0)]
-            public void* Handle;
-
-            public #raw_repr(#ident orig)
-            {
-                this.Handle = orig._handle;
-            }
-        }
-
         #raw_conversions
     }
 }
 
-pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
+pub fn quote_method_binding(item: &Method, types: &TypeMap) -> TokenStream {
     // Determine the name of the generated wrapper class based on the self type.
     let class_name = match &item.self_type {
         Schema::Struct(struct_) => &struct_.name,
@@ -99,21 +87,20 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
     // * A non-static method.
     // * A static method.
     let wrapper_fn = if is_constructor {
-        let binding = format_ident!("{}", &*item.binding);
-        let args = quote_args(item.inputs(), type_map);
-        let invoke_args = quote_invoke_args(item.inputs());
-
-        let invoke = fold_fixed_blocks(
-            quote! { _handle = __bindings.#binding(#invoke_args).Handle; },
+        let args = func::quote_args(item.inputs(), types);
+        let body = func::quote_wrapper_body(
+            &item.binding,
+            None,
             &item.inputs().collect::<Vec<_>>(),
+            Some(&quote! { this._handle }),
+            types,
         );
 
         quote! {
             public #class_ident(#( #args ),*)
             {
-                unsafe
-                {
-                    #invoke
+                unsafe {
+                    #body
                 }
             }
         }
@@ -122,22 +109,22 @@ pub fn quote_method_binding(item: &Method, type_map: &TypeMap) -> TokenStream {
         // correctly by passing the handle pointer directly, but in order to handle
         // `self` we'll need some concept of "consuming" the handle. Likely this will
         // meaning setting the handle to `null` after calling the function.
-        quote_wrapper_fn(
+        func::quote_wrapper_fn(
             &*item.name,
             &*item.binding,
             Some(quote! { this._handle }),
             item.inputs(),
             item.output.as_ref(),
-            type_map,
+            types,
         )
     } else {
-        quote_wrapper_fn(
+        func::quote_wrapper_fn(
             &*item.name,
             &*item.binding,
             None,
             item.inputs(),
             item.output.as_ref(),
-            type_map,
+            types,
         )
     };
 

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -96,7 +96,7 @@ fn from_raw_impl(export: &NamedType, schema: &Enum) -> TokenStream {
                 case #discriminants:
                 {
                     #convert_variants
-                }
+                } break;
             )*
 
             default: throw new Exception("Invalid discriminant " + raw.Discriminant);
@@ -156,11 +156,11 @@ fn into_raw_impl(export: &NamedType, schema: &Enum) -> TokenStream {
                     result = new #raw_struct_ty(
                         #discriminant,
                         new #union_ty() { #convert_union_field });
-                }
+                } break;
             )*
 
             default:
-                throw new Exception("Unrecognized enum variant: " + self);
+                throw new Exception("Unrecognized enum variant: " + value);
         }
     }
 }

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -22,12 +22,12 @@ pub fn quote_enum(export: &NamedType, schema: &Enum, types: &TypeMap) -> TokenSt
     let from_raw_impl = from_raw_impl(export, schema);
     let into_raw_impl = into_raw_impl(export, schema);
     let raw_conversions = binding::wrap_bindings(quote! {
-        internal static #repr #from_raw(#raw_repr raw)
+        internal static void #from_raw(#raw_repr raw, out #repr result)
         {
             #from_raw_impl
         }
 
-        internal static #raw_repr #into_raw(#repr self)
+        internal static void #into_raw(#repr value, out #raw_repr result)
         {
             #into_raw_impl
         }
@@ -53,7 +53,7 @@ pub fn quote_type_reference(export: &NamedType, schema: &Enum) -> TokenStream {
 /// communicating with Rust. On the C# side, C-like enums are always represented as
 /// `int` under the hood, and complex enums don't have a specific discriminant since
 /// they are represented using an interface.
-fn quote_discriminant_type(schema: &Enum) -> TokenStream {
+pub fn quote_discriminant_type(schema: &Enum) -> TokenStream {
     schema
         .repr
         .map(quote_primitive_type)
@@ -65,7 +65,7 @@ fn from_raw_impl(export: &NamedType, schema: &Enum) -> TokenStream {
     // the C# enum type.
     if !schema.has_data() {
         let cs_repr = quote_type_reference(export, schema);
-        return quote! { return (#cs_repr)raw; };
+        return quote! { result = (#cs_repr)raw; };
     }
 
     let discriminants = schema
@@ -79,12 +79,12 @@ fn from_raw_impl(export: &NamedType, schema: &Enum) -> TokenStream {
 
         if variant.is_empty() {
             quote! {
-                return new #cs_repr();
+                result = new #cs_repr();
             }
         } else {
             let union_field = format_ident!("{}", variant.name());
             quote! {
-                return new #cs_repr(raw.Value.#union_field);
+                result = new #cs_repr(raw.Value.#union_field);
             }
         }
     });
@@ -105,11 +105,12 @@ fn from_raw_impl(export: &NamedType, schema: &Enum) -> TokenStream {
 }
 
 fn into_raw_impl(export: &NamedType, schema: &Enum) -> TokenStream {
-    // For C-like enums, the conversion is just invoking the constructor of the raw struct.
+    // For C-like enums, the conversion is just casting the C# enum value to the
+    // appropriate discriminant type.
     if !schema.has_data() {
-        let raw_ident = binding::raw_ident(&export.name);
+        let discriminant_ty = quote_discriminant_type(schema);
         return quote! {
-            return new #raw_ident(self);
+            result = (#discriminant_ty)value;
         };
     }
 
@@ -147,12 +148,12 @@ fn into_raw_impl(export: &NamedType, schema: &Enum) -> TokenStream {
     });
 
     quote! {
-        switch (self)
+        switch (value)
         {
             #(
                 case #variant_type #variant_name:
                 {
-                    return new #raw_struct_ty(
+                    result = new #raw_struct_ty(
                         #discriminant,
                         new #union_ty() { #convert_union_field });
                 }
@@ -287,7 +288,7 @@ fn quote_complex_enum(export: &NamedType, schema: &Enum, types: &TypeMap) -> Tok
                 internal #ident(#raw_ident raw)
                 {
                     #(
-                        this.#field_ident = #bindings.#from_raw_fn(raw.#field_ident);
+                        #bindings.#from_raw_fn(raw.#field_ident, out this.#field_ident);
                     )*
                 }
             }
@@ -300,10 +301,10 @@ fn quote_complex_enum(export: &NamedType, schema: &Enum, types: &TypeMap) -> Tok
 
                 // Generate a constructor that converts the C# representation of the variant into
                 // its raw representation.
-                public #raw_ident(#ident self)
+                public #raw_ident(#ident value)
                 {
                     #(
-                        this.#field_ident = #bindings.#into_raw_fn(self.#field_ident);
+                        #bindings.#into_raw_fn(value.#field_ident, out this.#field_ident);
                     )*
                 }
             }

--- a/cs-bindgen-cli/src/generate/enumeration.rs
+++ b/cs-bindgen-cli/src/generate/enumeration.rs
@@ -189,29 +189,9 @@ fn quote_simple_enum(export: &NamedType, schema: &Enum) -> TokenStream {
         }
     });
 
-    let raw_ident = binding::raw_ident(&export.name);
-    let discriminant_ty = quote_discriminant_type(schema);
-
     quote! {
         public enum #ident {
             #( #variants ),*
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal unsafe struct #raw_ident
-        {
-            [FieldOffset(0)]
-            public #discriminant_ty Inner;
-
-            public #raw_ident(#ident self)
-            {
-                this.Inner = (#discriminant_ty)self;
-            }
-
-            public static explicit operator #ident(#raw_ident raw)
-            {
-                return (#ident)raw.Inner;
-            }
         }
     }
 }

--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -5,7 +5,6 @@ use cs_bindgen_shared::*;
 use heck::*;
 use proc_macro2::TokenStream;
 use quote::*;
-use syn::{punctuated::Punctuated, token::Comma, Ident};
 
 pub fn quote_wrapper_fn<'a>(
     name: &str,
@@ -28,13 +27,25 @@ pub fn quote_wrapper_fn<'a>(
     // Generate the declaration for the output variable and return expression. We need
     // to treat `void` returns as a special case, since C# won't let you declare values
     // with type `void` (*sigh*).
-    let ret = format_ident!("__ret");
+    let ret = quote! { __raw_result };
     let ret_decl = match output {
-        Some(_) => quote! { #return_ty #ret; },
+        Some(schema) => {
+            let raw_return_ty = binding::quote_raw_type_reference(schema, types);
+            quote! { #raw_return_ty #ret; }
+        }
+
         None => quote! {},
     };
+
+    let binding_class = binding::bindings_class_ident();
+    let from_raw = binding::from_raw_fn_ident();
+
     let ret_expr = match output {
-        Some(_) => quote! { return #ret; },
+        Some(_) => quote! {
+            #binding_class.#from_raw(#ret, out #return_ty __result);
+            return __result;
+        },
+
         None => quote! {},
     };
 
@@ -51,44 +62,27 @@ pub fn quote_wrapper_fn<'a>(
         binding,
         receiver,
         &inputs.collect::<Vec<_>>(),
-        output,
-        &ret,
+        output.map(|_| &ret),
         types,
     );
 
     quote! {
         public #static_ #return_ty #name(#( #args ),*)
         {
-            #ret_decl
             unsafe {
+                #ret_decl
                 #body
+                #ret_expr
             }
-            #ret_expr
         }
     }
 }
 
-pub fn quote_invoke_args<'a>(
-    args: impl Iterator<Item = (&'a str, &'a Schema)>,
-) -> Punctuated<TokenStream, Comma> {
-    let bindings = binding::bindings_class_ident();
-    let into_raw = binding::into_raw_fn_ident();
-
-    args.map(|(name, _)| {
-        let ident = format_ident!("{}", name.to_mixed_case());
-        quote! {
-            #bindings.#into_raw(#ident)
-        }
-    })
-    .collect::<Punctuated<_, Comma>>()
-}
-
-fn quote_wrapper_body<'a>(
+pub fn quote_wrapper_body<'a>(
     binding_name: &str,
     receiver: Option<TokenStream>,
     args: &[(&'a str, &'a Schema)],
-    output: Option<&Schema>,
-    ret: &Ident,
+    output: Option<&TokenStream>,
     types: &TypeMap,
 ) -> TokenStream {
     let arg_name = args.iter().map(|(name, _)| format_ident!("{}", name));
@@ -98,7 +92,6 @@ fn quote_wrapper_body<'a>(
         .map(|(_, ty)| binding::quote_raw_type_reference(ty, types));
 
     let bindings = binding::bindings_class_ident();
-    let from_raw = binding::from_raw_fn_ident();
     let into_raw = binding::into_raw_fn_ident();
 
     // Build the list of arguments to the wrapper function and insert the receiver at
@@ -115,9 +108,10 @@ fn quote_wrapper_body<'a>(
 
     // Generate the expression for invoking the raw function. If
     let invoke = quote! { #bindings.#raw_fn(#( #invoke_arg ),*) };
-    let invoke = match output {
-        Some(_) => quote! { #bindings.#from_raw(#invoke, out #ret); },
-        None => quote! { #invoke; },
+
+    let out_equals = match output {
+        Some(output) => quote! { #output = },
+        None => quote! {},
     };
 
     let body = quote! {
@@ -125,16 +119,13 @@ fn quote_wrapper_body<'a>(
             #bindings.#into_raw(#arg_name, out #raw_ty #temp_arg_name);
         )*
 
-        #invoke
+        #out_equals #invoke;
     };
 
     fold_fixed_blocks(body, args)
 }
 
-pub fn fold_fixed_blocks<'a>(
-    base_invoke: TokenStream,
-    args: &[(&'a str, &'a Schema)],
-) -> TokenStream {
+fn fold_fixed_blocks<'a>(base_invoke: TokenStream, args: &[(&'a str, &'a Schema)]) -> TokenStream {
     // Wrap the body of the function in `fixed` blocks for any parameters that need to
     // be passed as pointers to Rust (just strings for now). We use `Iterator::fold` to
     // generate a series of nested `fixed` blocks. This is very smart code and won't be
@@ -160,11 +151,11 @@ pub fn fold_fixed_blocks<'a>(
 /// Attempts to use the most idiomatic C# type that corresponds to the original type.
 pub fn quote_args<'a>(
     args: impl Iterator<Item = (&'a str, &'a Schema)> + 'a,
-    type_map: &'a TypeMap<'_>,
+    types: &'a TypeMap<'_>,
 ) -> impl Iterator<Item = TokenStream> + 'a {
     args.map(move |(name, schema)| {
         let ident = format_ident!("{}", name.to_mixed_case());
-        let ty = quote_cs_type(schema, type_map);
+        let ty = quote_cs_type(schema, types);
         quote! { #ty #ident }
     })
 }

--- a/cs-bindgen-cli/src/generate/strukt.rs
+++ b/cs-bindgen-cli/src/generate/strukt.rs
@@ -34,14 +34,14 @@ pub fn quote_struct(export: &NamedType, schema: StructLike<'_>, types: &TypeMap)
     let into_raw = binding::into_raw_fn_ident();
 
     let raw_conversions = binding::wrap_bindings(quote! {
-        internal static #ident #from_raw(#raw_ident raw)
+        internal static void #from_raw(#raw_ident raw, out #ident result)
         {
-            return new #ident(raw);
+            result = new #ident(raw);
         }
 
-        internal static #raw_ident #into_raw(#ident self)
+        internal static void #into_raw(#ident self, out #raw_ident result)
         {
-            return new #raw_ident(self);
+            result = new #raw_ident(self);
         }
     });
 
@@ -55,7 +55,7 @@ pub fn quote_struct(export: &NamedType, schema: StructLike<'_>, types: &TypeMap)
             internal #ident(#raw_ident raw)
             {
                 #(
-                    this.#field_ident = #bindings.#from_raw(raw.#field_ident);
+                    #bindings.#from_raw(raw.#field_ident, out this.#field_ident);
                 )*
             }
         }
@@ -67,7 +67,7 @@ pub fn quote_struct(export: &NamedType, schema: StructLike<'_>, types: &TypeMap)
             internal #raw_ident(#ident self)
             {
                 #(
-                    this.#field_ident = #bindings.#into_raw(self.#field_ident);
+                    #bindings.#into_raw(self.#field_ident, out this.#field_ident);
                 )*
             }
         }

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "c9ec069" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "525980b" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -1,0 +1,8 @@
+//! Tests verifying that collection types (e.g. arrays and maps) can be used with C#.
+
+use cs_bindgen::prelude::*;
+
+// #[cs_bindgen]
+pub fn return_vec() -> Vec<i32> {
+    vec![1, 2, 3, 4]
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,5 +1,6 @@
 use cs_bindgen::prelude::*;
 
+pub mod collections;
 pub mod copy_types;
 pub mod data_enum;
 pub mod name_collision;


### PR DESCRIPTION
Change the `__FromRaw()` and `__IntoRaw()` conversion functions to take an `out` parameter instead of directly returning their output. This allows overload resolution to take the output type into account, removing the need for a unique C# type corresponding to every Rust type used in an ABI boundary.

For example, we previously needed a separate `RustBool` struct so that we could have separate overloads of `__FromRaw` for `byte` and `bool` (since both `u8` and `bool` are represented as `byte` on the C# side). Now, we can have multiple overloads of `__FromRaw` that take `byte` as the input as long as their output types differ.

This change complicates the generated code for functions, since we can no longer chain functions together as easily. However, the extra complication in the generated code is worth it, since this change drastically reduces the amount of monomorphization that we will need to perform when handling generic types (e.g. collection types).