### PR TITLE
Add support for returning lists of primitives from Rust functions

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -107,9 +107,73 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         // Bindings to built-in helper functions.
         [DllImport(
             #dll_name,
-            EntryPoint = "__cs_bindgen_drop_string",
             CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void __cs_bindgen_drop_string(RawVec raw);
+        internal static extern void __cs_bindgen_drop_vec_u8(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_i8(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_u16(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_i16(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_u32(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_i32(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_u64(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_i64(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_usize(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_isize(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_f32(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_f64(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_bool(RawVec raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void __cs_bindgen_drop_vec_char(RawVec raw);
 
         [DllImport(
             #dll_name,
@@ -137,23 +201,73 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         internal static void __FromRaw(RawVec raw, out string result)
         {
             result = Encoding.UTF8.GetString((byte*)raw.Ptr, (int)raw.Length);
-            __bindings.__cs_bindgen_drop_string(raw);
+            __bindings.__cs_bindgen_drop_vec_u8(raw);
         }
 
-        internal static void __FromRaw(RawVec raw, out List<byte> result) { result = raw.ToPrimitiveList<byte>(); }
-        internal static void __FromRaw(RawVec raw, out List<sbyte> result) { result = raw.ToPrimitiveList<sbyte>(); }
-        internal static void __FromRaw(RawVec raw, out List<short> result) { result = raw.ToPrimitiveList<short>(); }
-        internal static void __FromRaw(RawVec raw, out List<ushort> result) { result = raw.ToPrimitiveList<ushort>(); }
-        internal static void __FromRaw(RawVec raw, out List<int> result) { result = raw.ToPrimitiveList<int>(); }
-        internal static void __FromRaw(RawVec raw, out List<uint> result) { result = raw.ToPrimitiveList<uint>(); }
-        internal static void __FromRaw(RawVec raw, out List<long> result) { result = raw.ToPrimitiveList<long>(); }
-        internal static void __FromRaw(RawVec raw, out List<ulong> result) { result = raw.ToPrimitiveList<ulong>(); }
-        internal static void __FromRaw(RawVec raw, out List<float> result) { result = raw.ToPrimitiveList<float>(); }
-        internal static void __FromRaw(RawVec raw, out List<double> result) { result = raw.ToPrimitiveList<double>(); }
+        internal static void __FromRaw(RawVec raw, out List<byte> result)
+        {
+            result = raw.ToPrimitiveList<byte>();
+            __bindings.__cs_bindgen_drop_vec_u8(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<sbyte> result)
+        {
+            result = raw.ToPrimitiveList<sbyte>();
+            __bindings.__cs_bindgen_drop_vec_i8(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<short> result)
+        {
+            result = raw.ToPrimitiveList<short>();
+            __bindings.__cs_bindgen_drop_vec_i16(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<ushort> result)
+        {
+            result = raw.ToPrimitiveList<ushort>();
+            __bindings.__cs_bindgen_drop_vec_u16(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<int> result)
+        {
+            result = raw.ToPrimitiveList<int>();
+            __bindings.__cs_bindgen_drop_vec_i32(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<uint> result)
+        {
+            result = raw.ToPrimitiveList<uint>();
+            __bindings.__cs_bindgen_drop_vec_u32(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<long> result)
+        {
+            result = raw.ToPrimitiveList<long>();
+            __bindings.__cs_bindgen_drop_vec_i64(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<ulong> result)
+        {
+            result = raw.ToPrimitiveList<ulong>();
+            __bindings.__cs_bindgen_drop_vec_u64(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<float> result)
+        {
+            result = raw.ToPrimitiveList<float>();
+            __bindings.__cs_bindgen_drop_vec_f32(raw);
+        }
+
+        internal static void __FromRaw(RawVec raw, out List<double> result)
+        {
+            result = raw.ToPrimitiveList<double>();
+            __bindings.__cs_bindgen_drop_vec_f32(raw);
+        }
 
         internal static void __FromRaw(RawVec raw, out List<bool> result)
         {
             result = raw.ToPrimitiveList<byte, bool>(raw => raw != 0);
+            __bindings.__cs_bindgen_drop_vec_u8(raw);
         }
 
         // Overloads of `__IntoRaw` for primitives and built-in types.

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -140,6 +140,11 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             __bindings.__cs_bindgen_drop_string(raw);
         }
 
+        internal static void __FromRaw(RawVec raw, out List<int> result)
+        {
+            result = raw.ToPrimitiveList<int>();
+        }
+
         // Overloads of `__IntoRaw` for primitives and built-in types.
         internal static void __IntoRaw(byte value, out byte result) { result = value; }
         internal static void __IntoRaw(sbyte value, out sbyte result) { result = value; }
@@ -188,6 +193,19 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             public void* Ptr;
             public UIntPtr Length;
             public UIntPtr Capacity;
+
+            public List<T> ToPrimitiveList<T>() where T: unmanaged
+            {
+                var result = new List<T>((int)Length);
+                var orig = (T*)Ptr;
+
+                for (int index = 0; index < (int)Length; index += 1)
+                {
+                    result.Add(orig[index]);
+                }
+
+                return result;
+            }
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -131,7 +131,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
 
         internal static void __FromRaw(byte raw, out bool result)
         {
-            result = raw != 0 ? true : false;
+            result = raw != 0;
         }
 
         internal static void __FromRaw(RawVec raw, out string result)
@@ -140,9 +140,20 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             __bindings.__cs_bindgen_drop_string(raw);
         }
 
-        internal static void __FromRaw(RawVec raw, out List<int> result)
+        internal static void __FromRaw(RawVec raw, out List<byte> result) { result = raw.ToPrimitiveList<byte>(); }
+        internal static void __FromRaw(RawVec raw, out List<sbyte> result) { result = raw.ToPrimitiveList<sbyte>(); }
+        internal static void __FromRaw(RawVec raw, out List<short> result) { result = raw.ToPrimitiveList<short>(); }
+        internal static void __FromRaw(RawVec raw, out List<ushort> result) { result = raw.ToPrimitiveList<ushort>(); }
+        internal static void __FromRaw(RawVec raw, out List<int> result) { result = raw.ToPrimitiveList<int>(); }
+        internal static void __FromRaw(RawVec raw, out List<uint> result) { result = raw.ToPrimitiveList<uint>(); }
+        internal static void __FromRaw(RawVec raw, out List<long> result) { result = raw.ToPrimitiveList<long>(); }
+        internal static void __FromRaw(RawVec raw, out List<ulong> result) { result = raw.ToPrimitiveList<ulong>(); }
+        internal static void __FromRaw(RawVec raw, out List<float> result) { result = raw.ToPrimitiveList<float>(); }
+        internal static void __FromRaw(RawVec raw, out List<double> result) { result = raw.ToPrimitiveList<double>(); }
+
+        internal static void __FromRaw(RawVec raw, out List<bool> result)
         {
-            result = raw.ToPrimitiveList<int>();
+            result = raw.ToPrimitiveList<byte, bool>(raw => raw != 0);
         }
 
         // Overloads of `__IntoRaw` for primitives and built-in types.
@@ -202,6 +213,19 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 for (int index = 0; index < (int)Length; index += 1)
                 {
                     result.Add(orig[index]);
+                }
+
+                return result;
+            }
+
+            public List<T> ToPrimitiveList<D, T>(Func<D, T> conversion) where D: unmanaged
+            {
+                var result = new List<T>((int)Length);
+                var orig = (D*)Ptr;
+
+                for (int index = 0; index < (int)Length; index += 1)
+                {
+                    result.Add(conversion(orig[index]));
                 }
 
                 return result;

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "525980b" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "6decc4f" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen/src/exports.rs
+++ b/cs-bindgen/src/exports.rs
@@ -14,11 +14,36 @@
 //!
 //! [`export`]: ../macro.export.html
 
-use crate::abi::{RawSlice, RawString};
+use crate::abi::{RawSlice, RawString, RawVec};
 
-/// Drops a `CString` that has been passed to the .NET runtime.
-pub unsafe fn __cs_bindgen_drop_string(raw: RawString) {
-    let _ = raw.into_string();
+macro_rules! drop_vec {
+    ( $( $prim:ty => $fn_name:ident, )* ) => {
+        $(
+            pub unsafe fn $fn_name(raw: RawVec<$prim>) {
+                let _ = raw.into_vec();
+            }
+        )*
+    }
+}
+
+drop_vec! {
+    u8 => __cs_bindgen_drop_vec_u8,
+    u16 => __cs_bindgen_drop_vec_u16,
+    u32 => __cs_bindgen_drop_vec_u32,
+    u64 => __cs_bindgen_drop_vec_u64,
+    usize => __cs_bindgen_drop_vec_usize,
+
+    i8 => __cs_bindgen_drop_vec_i8,
+    i16 => __cs_bindgen_drop_vec_i16,
+    i32 => __cs_bindgen_drop_vec_i32,
+    i64 => __cs_bindgen_drop_vec_i64,
+    isize => __cs_bindgen_drop_vec_isize,
+
+    f32 => __cs_bindgen_drop_vec_f32,
+    f64 => __cs_bindgen_drop_vec_f64,
+
+    bool => __cs_bindgen_drop_vec_bool,
+    char => __cs_bindgen_drop_vec_char,
 }
 
 /// Converts a C# string (i.e. a UTF-16 slice) into a Rust string.

--- a/cs-bindgen/src/lib.rs
+++ b/cs-bindgen/src/lib.rs
@@ -31,7 +31,24 @@ macro_rules! export {
     };
 
     () => {
-        $crate::export!(fn __cs_bindgen_drop_string(raw: $crate::abi::RawString));
         $crate::export!(fn __cs_bindgen_string_from_utf16(raw: $crate::abi::RawSlice<u16>) -> $crate::abi::RawString);
+
+        $crate::export!(fn __cs_bindgen_drop_vec_u8(raw: $crate::abi::RawVec<u8>));
+        $crate::export!(fn __cs_bindgen_drop_vec_u16(raw: $crate::abi::RawVec<u16>));
+        $crate::export!(fn __cs_bindgen_drop_vec_u32(raw: $crate::abi::RawVec<u32>));
+        $crate::export!(fn __cs_bindgen_drop_vec_u64(raw: $crate::abi::RawVec<u64>));
+        $crate::export!(fn __cs_bindgen_drop_vec_usize(raw: $crate::abi::RawVec<usize>));
+
+        $crate::export!(fn __cs_bindgen_drop_vec_i8(raw: $crate::abi::RawVec<i8>));
+        $crate::export!(fn __cs_bindgen_drop_vec_i16(raw: $crate::abi::RawVec<i16>));
+        $crate::export!(fn __cs_bindgen_drop_vec_i32(raw: $crate::abi::RawVec<i32>));
+        $crate::export!(fn __cs_bindgen_drop_vec_i64(raw: $crate::abi::RawVec<i64>));
+        $crate::export!(fn __cs_bindgen_drop_vec_isize(raw: $crate::abi::RawVec<isize>));
+
+        $crate::export!(fn __cs_bindgen_drop_vec_f32(raw: $crate::abi::RawVec<f32>));
+        $crate::export!(fn __cs_bindgen_drop_vec_f64(raw: $crate::abi::RawVec<f64>));
+
+        $crate::export!(fn __cs_bindgen_drop_vec_bool(raw: $crate::abi::RawVec<bool>));
+        $crate::export!(fn __cs_bindgen_drop_vec_char(raw: $crate::abi::RawVec<char>));
     };
 }

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace TestRunner
+{
+    public class Collections
+    {
+        [Fact]
+        public void ReturnVecInt()
+        {
+            var expected = IntegrationTests.ReturnVec();
+            var actual = new List<int>() { 1, 2, 3, 4 };
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReturnVecIntRepeated()
+        {
+            for (var count = 0; count < 100_000; count += 1)
+            {
+                var expected = IntegrationTests.ReturnVec();
+                var actual = new List<int>() { 1, 2, 3, 4 };
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+}

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -8,7 +8,7 @@ namespace TestRunner
         [Fact]
         public void ReturnVecInt()
         {
-            var expected = IntegrationTests.ReturnVec();
+            var expected = IntegrationTests.ReturnVecI32();
             var actual = new List<int>() { 1, 2, 3, 4 };
             Assert.Equal(expected, actual);
         }
@@ -18,10 +18,26 @@ namespace TestRunner
         {
             for (var count = 0; count < 100_000; count += 1)
             {
-                var expected = IntegrationTests.ReturnVec();
+                var expected = IntegrationTests.ReturnVecI32();
                 var actual = new List<int>() { 1, 2, 3, 4 };
                 Assert.Equal(expected, actual);
             }
+        }
+
+        [Fact]
+        public void ReturnVecFloat()
+        {
+            var expected = IntegrationTests.ReturnVecF32();
+            var actual = new List<float>() { 1.0f, 2.1f, 3.123f, 4.00000004f };
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReturnVecBool()
+        {
+            var expected = IntegrationTests.ReturnVecBool();
+            var actual = new List<bool>() { true, false, true, true };
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -2,7 +2,7 @@
 
 use cs_bindgen::prelude::*;
 
-// #[cs_bindgen]
+#[cs_bindgen]
 pub fn return_vec() -> Vec<i32> {
     vec![1, 2, 3, 4]
 }

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -3,6 +3,56 @@
 use cs_bindgen::prelude::*;
 
 #[cs_bindgen]
-pub fn return_vec() -> Vec<i32> {
+pub fn return_vec_i8() -> Vec<i8> {
     vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_u8() -> Vec<u8> {
+    vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_i16() -> Vec<i16> {
+    vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_u16() -> Vec<u16> {
+    vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_i32() -> Vec<i32> {
+    vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_u32() -> Vec<u32> {
+    vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_i64() -> Vec<i64> {
+    vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_u64() -> Vec<u64> {
+    vec![1, 2, 3, 4]
+}
+
+#[cs_bindgen]
+pub fn return_vec_f32() -> Vec<f32> {
+    vec![1.0, 2.1, 3.123, 4.00000004]
+}
+
+#[cs_bindgen]
+pub fn return_vec_f64() -> Vec<f64> {
+    vec![1.0, 2.1, 3.123, 4.00000004]
+}
+
+#[cs_bindgen]
+pub fn return_vec_bool() -> Vec<bool> {
+    vec![true, false, true, true]
 }


### PR DESCRIPTION
This PR makes it possible to return `Vec<T>` from Rust functions, where `T` is one of the primitive types. This is a first step towards full support for marshaling lists of data.