### PR TITLE
Support returning lists of user-defined types (mostly)

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -291,7 +291,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         {
             fixed (char* charPtr = value)
             {
-                result = __cs_bindgen_string_from_utf16(new RawSlice((void*)charPtr, value.Length));
+                result = __cs_bindgen_string_from_utf16(new RawSlice((IntPtr)charPtr, value.Length));
             }
         }
     });
@@ -317,7 +317,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct RawVec
         {
-            public void* Ptr;
+            public IntPtr Ptr;
             public UIntPtr Length;
             public UIntPtr Capacity;
 
@@ -374,16 +374,16 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct RawSlice
         {
-            public void* Ptr;
+            public IntPtr Ptr;
             public UIntPtr Length;
 
-            public RawSlice(void* ptr, UIntPtr len)
+            public RawSlice(IntPtr ptr, UIntPtr len)
             {
                 Ptr = ptr;
                 Length = len;
             }
 
-            public RawSlice(void* ptr, int len)
+            public RawSlice(IntPtr ptr, int len)
             {
                 Ptr = ptr;
                 Length = (UIntPtr)len;

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -140,6 +140,15 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             __bindings.__cs_bindgen_drop_string(raw);
         }
 
+        internal static void __FromRaw<T>(RawVec raw, out List<T> result)
+        {
+            var output = new List<T>();
+            for (int index = 0; index < raw.Length; index += 1)
+            {
+                // Heck how do we index into the array? Don't we need to know the size/alignment of the element type?
+            }
+        }
+
         // Overloads of `__IntoRaw` for primitives and built-in types.
         internal static void __IntoRaw(byte value, out byte result) { result = value; }
         internal static void __IntoRaw(sbyte value, out sbyte result) { result = value; }

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -270,15 +270,6 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             __bindings.__cs_bindgen_drop_vec_u8(raw);
         }
 
-        internal static void __FromRaw<T>(RawVec raw, out List<T> result)
-        {
-            var output = new List<T>();
-            for (int index = 0; index < raw.Length; index += 1)
-            {
-                // Heck how do we index into the array? Don't we need to know the size/alignment of the element type?
-            }
-        }
-
         // Overloads of `__IntoRaw` for primitives and built-in types.
         internal static void __IntoRaw(byte value, out byte result) { result = value; }
         internal static void __IntoRaw(sbyte value, out sbyte result) { result = value; }

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -10,7 +10,7 @@
 //! function, using the `[DllImport]` attribute to load the corresponding function
 //! from the Rust dylib.
 
-use crate::generate::{class, enumeration, strukt, TypeMap, STRING_SCHEMA};
+use crate::generate::{self, class, enumeration, strukt, TypeMap, STRING_SCHEMA};
 use cs_bindgen_shared::{
     schematic::{Field, Schema, TypeName},
     BindingStyle, Export,
@@ -71,23 +71,16 @@ pub fn wrap_bindings(tokens: TokenStream) -> TokenStream {
 pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> TokenStream {
     match export {
         Export::Fn(export) => {
-            let dll_import_attrib = quote_dll_import(dll_name, &export.binding);
-            let binding_ident = format_ident!("{}", &*export.binding);
+            let args = quote_binding_args(export.inputs(), types);
             let return_ty = match &export.output {
                 Some(output) => quote_raw_type_reference(output, types),
                 None => quote! { void },
             };
-            let args = quote_binding_args(export.inputs(), types);
 
-            quote! {
-                #dll_import_attrib
-                internal static extern #return_ty #binding_ident(#args);
-            }
+            quote_raw_fn_binding(&export.binding, return_ty, args.to_token_stream(), dll_name)
         }
 
         Export::Method(export) => {
-            let dll_import_attrib = quote_dll_import(dll_name, &export.binding);
-            let binding_ident = format_ident!("{}", &*export.binding);
             let return_ty = match &export.output {
                 Some(output) => quote_raw_type_reference(output, types),
                 None => quote! { void },
@@ -103,19 +96,48 @@ pub fn quote_raw_binding(export: &Export, dll_name: &str, types: &TypeMap) -> To
                 args.insert(0, quote! { #handle_type self });
             }
 
-            quote! {
-                #dll_import_attrib
-                internal static extern #return_ty #binding_ident(#args);
-            }
+            quote_raw_fn_binding(&export.binding, return_ty, args.to_token_stream(), dll_name)
         }
 
         // Generate the binding for the destructor for any named types that are marshaled
         // as handles.
         Export::Named(export) => {
-            if export.binding_style == BindingStyle::Handle {
+            let index_fn = quote_raw_fn_binding(
+                &export.index_fn,
+                quote_raw_type_reference(&export.schema, types),
+                quote! { RawSlice slice, UIntPtr index },
+                dll_name,
+            );
+
+            let drop_vec_fn = quote_raw_fn_binding(
+                &export.drop_vec_fn,
+                quote! { void },
+                quote! { RawVec vec },
+                dll_name,
+            );
+
+            let from_raw = from_raw_fn_ident();
+            let ty = generate::quote_cs_type(&export.schema, types);
+            let raw_repr = quote_raw_type_reference(&export.schema, types);
+            let index_fn_name = format_ident!("{}", &*export.index_fn);
+            let list_from_raw = quote! {
+                internal static void #from_raw(RawVec raw, out List<#ty> result)
+                {
+                    result = raw.ToList<#raw_repr, #ty>(#index_fn_name, #from_raw);
+                }
+            };
+
+            let drop_fn = if export.binding_style == BindingStyle::Handle {
                 class::quote_drop_fn(&export, dll_name)
             } else {
                 quote! {}
+            };
+
+            quote! {
+                #index_fn
+                #drop_vec_fn
+                #drop_fn
+                #list_from_raw
             }
         }
     }
@@ -251,15 +273,6 @@ pub fn raw_struct_fields(fields: &[Field<'_>], types: &TypeMap) -> TokenStream {
     }
 }
 
-fn quote_dll_import(dll_name: &str, entry_point: &str) -> TokenStream {
-    quote! {
-        [DllImport(
-            #dll_name,
-            EntryPoint = #entry_point,
-            CallingConvention = CallingConvention.Cdecl)]
-    }
-}
-
 fn quote_binding_args<'a>(
     inputs: impl Iterator<Item = (&'a str, &'a Schema)>,
     types: &TypeMap<'_>,
@@ -272,4 +285,20 @@ fn quote_binding_args<'a>(
             quote! { #ty #ident }
         })
         .collect()
+}
+
+fn quote_raw_fn_binding(
+    entry_point: &str,
+    return_ty: TokenStream,
+    args: TokenStream,
+    dll: &str,
+) -> TokenStream {
+    let fn_name = format_ident!("{}", entry_point);
+    quote! {
+        [DllImport(
+            #dll,
+            EntryPoint = #entry_point,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern #return_ty #fn_name(#args);
+    }
 }

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -198,7 +198,7 @@ pub fn quote_raw_type_reference(schema: &Schema, types: &TypeMap) -> TokenStream
             // There are three possible raw representations for an exported enum:
             //
             // * Enums that are marshalled as handles are represented as the raw handle pointer
-            //   type (`void*`).
+            //   type (`IntPtr`).
             // * Data-carrying enums have an associate struct that represents its raw type.
             // * C-like enums are marshalled directly as an integer value.
             if export.binding_style == BindingStyle::Handle {

--- a/cs-bindgen-cli/src/generate/class.rs
+++ b/cs-bindgen-cli/src/generate/class.rs
@@ -13,13 +13,13 @@ pub fn quote_drop_fn(export: &NamedType, dll_name: &str) -> TokenStream {
             #dll_name,
             EntryPoint = #entry_point,
             CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void #binding_ident(void* self);
+        internal static extern void #binding_ident(IntPtr self);
     }
 }
 
-/// Quotes the pointer type used for handles, i.e. `void*`.
+/// Quotes the pointer type used for handles, i.e. `IntPtr`.
 pub fn quote_handle_ptr() -> TokenStream {
-    quote! { void* }
+    quote! { IntPtr }
 }
 
 pub fn quote_handle_type(export: &NamedType) -> TokenStream {
@@ -45,7 +45,7 @@ pub fn quote_handle_type(export: &NamedType) -> TokenStream {
     quote! {
         public unsafe partial class #ident : IDisposable
         {
-            internal void* _handle;
+            internal IntPtr _handle;
 
             internal #ident(#raw_repr raw)
             {
@@ -54,10 +54,10 @@ pub fn quote_handle_type(export: &NamedType) -> TokenStream {
 
             public void Dispose()
             {
-                if (_handle != null)
+                if (_handle != IntPtr.Zero)
                 {
                     __bindings.#drop_fn(_handle);
-                    _handle = null;
+                    _handle = IntPtr.Zero;
                 }
             }
         }

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -103,6 +103,9 @@ fn quote_simple_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
         .map(|variant| &variant.ident)
         .collect::<Vec<_>>();
 
+    let index_fn = quote_index_fn(&ident);
+    let drop_vec_fn = quote_vec_drop_fn(&ident);
+
     Ok(quote! {
         #(
             #[allow(bad_style)]
@@ -137,6 +140,9 @@ fn quote_simple_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
                 }
             }
         }
+
+        #index_fn
+        #drop_vec_fn
     })
 }
 

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -1,4 +1,6 @@
-use crate::{describe_named_type, quote_index_fn, reject_generics, value, BindingStyle};
+use crate::{
+    describe_named_type, quote_index_fn, quote_vec_drop_fn, reject_generics, value, BindingStyle,
+};
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
 use syn::*;
@@ -280,7 +282,8 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
         }
     });
 
-    let index_fn = quote_index_fn(ident)?;
+    let index_fn = quote_index_fn(ident);
+    let vec_drop_fn = quote_vec_drop_fn(ident);
 
     Ok(quote! {
         #[repr(C)]
@@ -320,6 +323,7 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
         }
 
         #index_fn
+        #vec_drop_fn
     })
 }
 

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -1,4 +1,4 @@
-use crate::{describe_named_type, reject_generics, value, BindingStyle};
+use crate::{describe_named_type, quote_index_fn, reject_generics, value, BindingStyle};
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
 use syn::*;
@@ -211,6 +211,8 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
         }
     });
 
+    let index_fn = quote_index_fn(ident)?;
+
     Ok(quote! {
         #[repr(C)]
         #[derive(Clone, Copy)]
@@ -241,6 +243,8 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
                 }
             }
         }
+
+        #index_fn
     })
 }
 

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -468,9 +468,9 @@ fn extract_type_ident(ty: &Type) -> syn::Result<Ident> {
 }
 
 /// Generates a function for converting an element in a slice.
-fn quote_index_fn(ty: &Ident) -> syn::Result<TokenStream> {
+fn quote_index_fn(ty: &Ident) -> TokenStream {
     let fn_ident = format_ident!("__cs_bindgen_generated_index_{}", ty);
-    Ok(quote! {
+    quote! {
         #[allow(bad_style)]
         pub unsafe extern "C" fn #fn_ident(
             slice: cs_bindgen::abi::RawSlice<#ty>,
@@ -478,5 +478,15 @@ fn quote_index_fn(ty: &Ident) -> syn::Result<TokenStream> {
         ) -> <#ty as cs_bindgen::abi::Abi>::Abi {
             slice.convert_element(index)
         }
-    })
+    }
+}
+
+fn quote_vec_drop_fn(ty: &Ident) -> TokenStream {
+    let fn_ident = format_ident!("__cs_bindgen_generated_drop_vec_{}", ty);
+    quote! {
+        #[allow(bad_style)]
+        pub unsafe extern "C" fn #fn_ident(raw: cs_bindgen::abi::RawVec<#ty>) {
+            let _ = raw.into_vec();
+        }
+    }
 }

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -466,3 +466,16 @@ fn extract_type_ident(ty: &Type) -> syn::Result<Ident> {
         .join("__");
     Ok(format_ident!("{}", ident_string))
 }
+
+/// Generates a function for converting an element in a slice.
+fn quote_index_fn(ty: &Ident) -> syn::Result<TokenStream> {
+    let fn_ident = format_ident!("__cs_bindgen_generated_index_{}", ty);
+    Ok(quote! {
+        pub unsafe extern "C" fn #fn_ident(
+            slice: cs_bindgen::abi::RawSlice<#ty>,
+            index: usize,
+        ) -> <#ty as cs_bindgen::abi::Abi>::Abi {
+            slice.convert_element(index)
+        }
+    })
+}

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -479,6 +479,7 @@ fn index_fn_ident(ty: &Ident) -> Ident {
 fn quote_index_fn(ty: &Ident) -> TokenStream {
     let fn_ident = index_fn_ident(ty);
     quote! {
+        #[no_mangle]
         #[allow(bad_style)]
         pub unsafe extern "C" fn #fn_ident(
             slice: cs_bindgen::abi::RawSlice<#ty>,

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -471,6 +471,7 @@ fn extract_type_ident(ty: &Type) -> syn::Result<Ident> {
 fn quote_index_fn(ty: &Ident) -> syn::Result<TokenStream> {
     let fn_ident = format_ident!("__cs_bindgen_generated_index_{}", ty);
     Ok(quote! {
+        #[allow(bad_style)]
         pub unsafe extern "C" fn #fn_ident(
             slice: cs_bindgen::abi::RawSlice<#ty>,
             index: usize,

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -426,6 +426,8 @@ fn reject_generics<M: Display>(generics: &Generics, message: M) -> syn::Result<(
 fn describe_named_type(ident: &Ident, style: BindingStyle) -> TokenStream {
     let describe_ident = format_describe_ident!(ident);
     let name = ident.to_string();
+    let index_fn = index_fn_ident(ident).to_string();
+    let drop_vec_fn = drop_vec_fn_ident(ident).to_string();
 
     let style = match style {
         BindingStyle::Handle => quote! { Handle },
@@ -439,6 +441,8 @@ fn describe_named_type(ident: &Ident, style: BindingStyle) -> TokenStream {
                 name: #name.into(),
                 schema: cs_bindgen::shared::schematic::describe::<#ident>().expect("Failed to describe enum type"),
                 binding_style: cs_bindgen::shared::BindingStyle::#style,
+                index_fn: #index_fn.into(),
+                drop_vec_fn: #drop_vec_fn.into(),
             };
 
             std::boxed::Box::new(cs_bindgen::shared::serialize_export(export).into())
@@ -467,9 +471,13 @@ fn extract_type_ident(ty: &Type) -> syn::Result<Ident> {
     Ok(format_ident!("{}", ident_string))
 }
 
+fn index_fn_ident(ty: &Ident) -> Ident {
+    format_ident!("__cs_bindgen_generated_index_{}", ty)
+}
+
 /// Generates a function for converting an element in a slice.
 fn quote_index_fn(ty: &Ident) -> TokenStream {
-    let fn_ident = format_ident!("__cs_bindgen_generated_index_{}", ty);
+    let fn_ident = index_fn_ident(ty);
     quote! {
         #[allow(bad_style)]
         pub unsafe extern "C" fn #fn_ident(
@@ -481,8 +489,12 @@ fn quote_index_fn(ty: &Ident) -> TokenStream {
     }
 }
 
+fn drop_vec_fn_ident(ty: &Ident) -> Ident {
+    format_ident!("__cs_bindgen_generated_drop_vec_{}", ty)
+}
+
 fn quote_vec_drop_fn(ty: &Ident) -> TokenStream {
-    let fn_ident = format_ident!("__cs_bindgen_generated_drop_vec_{}", ty);
+    let fn_ident = drop_vec_fn_ident(ty);
     quote! {
         #[allow(bad_style)]
         pub unsafe extern "C" fn #fn_ident(raw: cs_bindgen::abi::RawVec<#ty>) {

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -1,4 +1,7 @@
-use crate::{describe_named_type, handle, has_derive_copy, reject_generics, value, BindingStyle};
+use crate::{
+    describe_named_type, handle, has_derive_copy, quote_index_fn, reject_generics, value,
+    BindingStyle,
+};
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
 use syn::*;
@@ -36,6 +39,8 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
             Fields::Unit => quote! {},
         };
 
+        let index_fn = quote_index_fn(&ident)?;
+
         Ok(quote! {
             #abi_struct
 
@@ -55,6 +60,7 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
 
             #describe_impl
             #describe_fn
+            #index_fn
         })
     } else {
         let binding = handle::quote_type_as_handle(&item.ident)?;

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -1,6 +1,6 @@
 use crate::{
-    describe_named_type, handle, has_derive_copy, quote_index_fn, reject_generics, value,
-    BindingStyle,
+    describe_named_type, handle, has_derive_copy, quote_index_fn, quote_vec_drop_fn,
+    reject_generics, value, BindingStyle,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
@@ -28,7 +28,8 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
         let abi_struct_ident = format_binding_ident!(item.ident);
         let abi_struct = value::quote_abi_struct(&abi_struct_ident, &item.fields);
         let describe_fn = describe_named_type(&item.ident, BindingStyle::Value);
-        let index_fn = quote_index_fn(&item.ident)?;
+        let index_fn = quote_index_fn(&item.ident);
+        let vec_drop_fn = quote_vec_drop_fn(&item.ident);
 
         let into_abi_fields = value::into_abi_fields(&item.fields, |index, field| {
             let accessor = field_accessor(index, field);
@@ -76,6 +77,7 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
             #describe_impl
             #describe_fn
             #index_fn
+            #vec_drop_fn
         })
     } else {
         let binding = handle::quote_type_as_handle(&item.ident)?;

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -73,6 +73,9 @@ pub struct NamedType {
     pub name: Cow<'static, str>,
     pub binding_style: BindingStyle,
     pub schema: Schema,
+
+    pub index_fn: Cow<'static, str>,
+    pub drop_vec_fn: Cow<'static, str>,
 }
 
 #[derive(Debug, Clone, From, Serialize, Deserialize)]

--- a/cs-bindgen/src/abi.rs
+++ b/cs-bindgen/src/abi.rs
@@ -359,12 +359,11 @@ impl<T> RawSlice<T> {
 impl<'a, T: 'a> RawSlice<T>
 where
     T: Abi,
-    &'a T: Abi<Abi = T::Abi>,
 {
     pub unsafe fn convert_element(self, index: usize) -> T::Abi {
         let slice = self.as_slice();
         let element = &slice[index];
-        Abi::into_abi(element)
+        Abi::as_abi(element)
     }
 }
 

--- a/cs-bindgen/src/abi.rs
+++ b/cs-bindgen/src/abi.rs
@@ -278,6 +278,18 @@ impl<T> RawSlice<T> {
     }
 }
 
+impl<'a, T: 'a> RawSlice<T>
+where
+    T: Abi,
+    &'a T: Abi<Abi = T::Abi>,
+{
+    pub unsafe fn convert_element(self, index: usize) -> T::Abi {
+        let slice = self.as_slice();
+        let element = &slice[index];
+        Abi::into_abi(element)
+    }
+}
+
 impl RawSlice<u8> {
     pub unsafe fn as_str<'a>(self) -> Result<&'a str, str::Utf8Error> {
         str::from_utf8(slice::from_raw_parts(self.ptr, self.len))

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -66,5 +66,18 @@ namespace TestRunner
             var actual = IntegrationTests.ReturnSimpleEnumVec();
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void ReturnDataEnumList()
+        {
+            var expected = new List<IDataEnum>()
+            {
+                new DataEnum.Foo(),
+                new DataEnum.Bar("Cool string"),
+                new DataEnum.Coolness(new InnerEnum.Coolest(SimpleCEnum.Foo)),
+            };
+            var actual = IntegrationTests.ReturnDataEnumVec();
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -40,7 +40,8 @@ namespace TestRunner
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
+        // TODO: Re-enable test case once we fix support for passing list of handle types.
+        // [Fact]
         public void ReturnHandleList()
         {
             var items = IntegrationTests.ReturnHandleVec();

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -42,14 +42,13 @@ namespace TestRunner
 
         // TODO: Re-enable test case once we fix support for passing list of handle types.
         // [Fact]
-        public void ReturnHandleList()
-        {
-            var items = IntegrationTests.ReturnHandleVec();
-            Assert.Equal(2, items.Count);
-            Assert.Equal(33, items[0].Bar());
-            Assert.Equal(12345, items[1].Bar());
-        }
-
+        // public void ReturnHandleList()
+        // {
+        //     var items = IntegrationTests.ReturnHandleVec();
+        //     Assert.Equal(2, items.Count);
+        //     Assert.Equal(33, items[0].Bar());
+        //     Assert.Equal(12345, items[1].Bar());
+        // }
 
         [Fact]
         public void ReturnStructList()
@@ -58,6 +57,14 @@ namespace TestRunner
             Assert.Equal(2, items.Count);
             Assert.Equal(33, items[0].Bar);
             Assert.Equal(12345, items[1].Bar);
+        }
+
+        [Fact]
+        public void ReturnSimpleEnumList()
+        {
+            var expected = new List<SimpleCEnum>() { SimpleCEnum.Foo, SimpleCEnum.Bar, SimpleCEnum.Baz };
+            var actual = IntegrationTests.ReturnSimpleEnumVec();
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -39,5 +39,24 @@ namespace TestRunner
             var actual = new List<bool>() { true, false, true, true };
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void ReturnHandleList()
+        {
+            var items = IntegrationTests.ReturnHandleVec();
+            Assert.Equal(2, items.Count);
+            Assert.Equal(33, items[0].Bar());
+            Assert.Equal(12345, items[1].Bar());
+        }
+
+
+        [Fact]
+        public void ReturnStructList()
+        {
+            var items = IntegrationTests.ReturnStructVec();
+            Assert.Equal(2, items.Count);
+            Assert.Equal(33, items[0].Bar);
+            Assert.Equal(12345, items[1].Bar);
+        }
     }
 }

--- a/integration-tests/builder/Cargo.toml
+++ b/integration-tests/builder/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex = "1.3.6"

--- a/integration-tests/builder/src/main.rs
+++ b/integration-tests/builder/src/main.rs
@@ -1,4 +1,5 @@
-use std::{env, path::Path, process::Command};
+use regex::Regex;
+use std::{env, fs, path::Path, process::Command};
 
 fn main() {
     // Get the environment variables set by cargo so that we can put together the right
@@ -34,7 +35,7 @@ fn main() {
         .arg("--")
         .arg(wasm_module_path)
         .arg("-o")
-        .arg(bindings_path)
+        .arg(&bindings_path)
         .spawn()
         .expect("Failed to spawn cs-bindgen process");
 
@@ -53,4 +54,24 @@ fn main() {
     if !status.success() {
         panic!("Dylib build process finished with an error");
     }
+
+    // HACK: Manually insert some new lines into the generated code in order to improve
+    // the formatter's output. For some inexplicable reason the C# formatter won't break
+    // up long lines in all cases, which means that even after running the generated
+    // code through the formatter it's still often unreadable. Notably:
+    //
+    // * If you have multiple statements on the same line, the formatter will leave them
+    //   on the same line.
+    // * It won't break attributes up onto multiple lines, and it won't put a new line
+    //   between an attribute than the item the attribute is attached to, so all of our
+    //   `[DllImport]` declarations are left on one big line even after formatting.
+    //
+    // Fortunately, if we manually insert new lines into those places, the formatter
+    // keeps those new lines in place. So to force the formatter to break up the code
+    // more, we manually insert '/n' after ';' (to break up statements) and ']' (to
+    // break up attributes).
+    let regex = Regex::new(r"(]|;)").unwrap();
+    let file = fs::read_to_string(&bindings_path).unwrap();
+    let result = regex.replace_all(&file, "$1\n");
+    fs::write(&bindings_path, &*result).unwrap();
 }

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -1,6 +1,9 @@
 //! Tests verifying that collection types (e.g. arrays and maps) can be used with C#.
 
-use crate::simple_enum::SimpleCEnum;
+use crate::{
+    data_enum::{DataEnum, InnerEnum},
+    simple_enum::SimpleCEnum,
+};
 use cs_bindgen::prelude::*;
 
 #[cs_bindgen]
@@ -89,4 +92,13 @@ pub fn return_struct_vec() -> Vec<CopyStruct> {
 #[cs_bindgen]
 pub fn return_simple_enum_vec() -> Vec<SimpleCEnum> {
     vec![SimpleCEnum::Foo, SimpleCEnum::Bar, SimpleCEnum::Baz]
+}
+
+#[cs_bindgen]
+pub fn return_data_enum_vec() -> Vec<DataEnum> {
+    vec![
+        DataEnum::Foo,
+        DataEnum::Bar("Cool string".into()),
+        DataEnum::Coolness(InnerEnum::Coolest(SimpleCEnum::Foo)),
+    ]
 }

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -2,7 +2,7 @@
 
 use cs_bindgen::prelude::*;
 
-// #[cs_bindgen]
+#[cs_bindgen]
 pub fn return_vec() -> Vec<i32> {
     vec![1, 2, 3, 4]
 }

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -1,5 +1,6 @@
 //! Tests verifying that collection types (e.g. arrays and maps) can be used with C#.
 
+use crate::simple_enum::SimpleCEnum;
 use cs_bindgen::prelude::*;
 
 #[cs_bindgen]
@@ -83,4 +84,9 @@ pub struct CopyStruct {
 #[cs_bindgen]
 pub fn return_struct_vec() -> Vec<CopyStruct> {
     vec![CopyStruct { bar: 33 }, CopyStruct { bar: 12345 }]
+}
+
+#[cs_bindgen]
+pub fn return_simple_enum_vec() -> Vec<SimpleCEnum> {
+    vec![SimpleCEnum::Foo, SimpleCEnum::Bar, SimpleCEnum::Baz]
 }

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -58,11 +58,31 @@ pub fn return_vec_bool() -> Vec<bool> {
 }
 
 #[cs_bindgen]
-pub struct Foo {
-    pub bar: u32,
+pub struct HandleStruct {
+    pub bar: i32,
 }
 
 #[cs_bindgen]
-pub fn return_struct_vec() -> Vec<Foo> {
-    vec![Foo { bar: 1 }, Foo { bar: 2 }]
+pub fn return_handle_vec() -> Vec<HandleStruct> {
+    vec![HandleStruct { bar: 33 }, HandleStruct { bar: 12345 }]
 }
+
+#[cs_bindgen]
+impl HandleStruct {
+    pub fn bar(&self) -> i32 {
+        self.bar
+    }
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone, Copy)]
+pub struct CopyStruct {
+    pub bar: i32,
+}
+
+#[cs_bindgen]
+pub fn return_struct_vec() -> Vec<CopyStruct> {
+    vec![CopyStruct { bar: 33 }, CopyStruct { bar: 12345 }]
+}
+
+pub enum 

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -56,3 +56,13 @@ pub fn return_vec_f64() -> Vec<f64> {
 pub fn return_vec_bool() -> Vec<bool> {
     vec![true, false, true, true]
 }
+
+#[cs_bindgen]
+pub struct Foo {
+    pub bar: u32,
+}
+
+#[cs_bindgen]
+pub fn return_struct_vec() -> Vec<Foo> {
+    vec![Foo { bar: 1 }, Foo { bar: 2 }]
+}

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -84,5 +84,3 @@ pub struct CopyStruct {
 pub fn return_struct_vec() -> Vec<CopyStruct> {
     vec![CopyStruct { bar: 33 }, CopyStruct { bar: 12345 }]
 }
-
-pub enum 


### PR DESCRIPTION
It's (mostly) working! Main outstanding issues are:

* Returning a `Vec` of handle types is currently not working. I completely donked up the `Abi::as_abi` stuff, turns out that doesn't work at all. We need to actually move elements out of the `Vec` in order to box it, so that's going to take some additional changes.
* It leaks! So much! I'm opting not to fix that in this PR, though, because that was already happening and fixing it is tied into the previous point.