### PR TITLE
Set C# language version to 7.3 for integration tests

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -266,7 +266,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
 
         internal static void __FromRaw(RawVec raw, out List<bool> result)
         {
-            result = raw.ToPrimitiveList<byte, bool>(raw => raw != 0);
+            result = raw.ToPrimitiveList<byte, bool>(rawElem => rawElem != 0);
             __bindings.__cs_bindgen_drop_vec_u8(raw);
         }
 

--- a/integration-tests/TestRunner/TestRunner.csproj
+++ b/integration-tests/TestRunner/TestRunner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/integration-tests/TestRunner/TestRunner.csproj
+++ b/integration-tests/TestRunner/TestRunner.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In order to support Unity, we need to stick to C# 7.3 and lower. I've setup the integration test project to target C# 7.3 in order to catch cases where the generated code might rely on functionality introduced in C# 8.0 or later. This change caught one case where we were relying on name shadowing in nested functions, which was added in C# 8.0.