### PR TITLE
Make handle types opaque

### DIFF
--- a/cs-bindgen-cli/Cargo.toml
+++ b/cs-bindgen-cli/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2018"
 
 [dependencies]
 cs-bindgen-shared = { version = "0.1.0", path = "../cs-bindgen-shared" }
+extend = "0.1.1"
 failure = "0.1.6"
 heck = "0.3.1"
 lazy_static = "1.4.0"
 parity-wasm = "0.41.0"
 proc-macro2 = "1.0.8"
-quote = "1.0.3"
+quote = "1.0.6"
 serde_json = "1.0.45"
 structopt = "0.3.8"
 syn = { version = "1.0.14", features = ["full"] }

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -422,7 +422,7 @@ fn quote_cs_type_for_repr(repr: &Repr, types: &TypeMap) -> TokenStream {
     let quote_sequence_type = |element| {
         let element = quote_cs_type_for_repr(element, types);
         quote! {
-            System.Collections.Generic.List<#element>
+            List<#element>
         }
     };
 

--- a/cs-bindgen-cli/src/generate/binding.rs
+++ b/cs-bindgen-cli/src/generate/binding.rs
@@ -185,7 +185,7 @@ pub fn raw_type_from_repr(repr: &Repr, types: &TypeMap) -> TokenStream {
                 .unwrap_or_else(|| panic!("No export found for named type {:?}", type_name));
 
             match &export.binding_style {
-                BindingStyle::Handle => named_type_raw_reference(type_name),
+                BindingStyle::Handle => class::quote_handle_ptr(),
                 BindingStyle::Value(schema) => raw_type_from_schema(schema, types),
             }
         }

--- a/cs-bindgen-cli/src/generate/strukt.rs
+++ b/cs-bindgen-cli/src/generate/strukt.rs
@@ -1,6 +1,6 @@
 //! Code generation for exported struct types.
 
-use crate::generate::{self, binding, TypeMap};
+use crate::generate::{self, binding, TypeMap, TypeNameExt};
 use cs_bindgen_shared::{
     schematic::{Field, StructLike},
     BindingStyle, NamedType,
@@ -13,12 +13,12 @@ use syn::Ident;
 pub fn quote_struct(export: &NamedType, schema: StructLike<'_>, types: &TypeMap) -> TokenStream {
     assert!(
         matches!(export.binding_style, BindingStyle::Value(..)),
-        "Trying to generate by-value marshaling for {} which is expected to be marshaled by handle",
-        export.name,
+        "Trying to generate by-value marshaling for {:?} which is expected to be marshaled by handle",
+        export.type_name,
     );
 
-    let ident = format_ident!("{}", &*export.name);
-    let raw_ident = binding::raw_ident(&export.name);
+    let ident = export.type_name.ident();
+    let raw_ident = binding::raw_ident(&export.type_name);
 
     let field_ident = schema
         .fields
@@ -88,7 +88,7 @@ pub fn struct_fields(fields: &[Field<'_>], types: &TypeMap) -> TokenStream {
 
     let field_ty = fields
         .iter()
-        .map(|field| generate::quote_cs_type(&field.schema, types));
+        .map(|field| generate::quote_cs_type_for_schema(&field.schema, types));
 
     quote! {
         #(
@@ -115,7 +115,7 @@ pub fn struct_constructor(ident: &Ident, fields: &[Field<'_>], types: &TypeMap) 
 
     let field_ty = fields
         .iter()
-        .map(|field| generate::quote_cs_type(&field.schema, types));
+        .map(|field| generate::quote_cs_type_for_schema(&field.schema, types));
 
     quote! {
         public #ident(#( #field_ty #arg_ident ),*)

--- a/cs-bindgen-cli/src/generate/strukt.rs
+++ b/cs-bindgen-cli/src/generate/strukt.rs
@@ -1,6 +1,6 @@
 //! Code generation for exported struct types.
 
-use crate::generate::{self, binding, class, TypeMap};
+use crate::generate::{self, binding, TypeMap};
 use cs_bindgen_shared::{
     schematic::{Field, StructLike},
     BindingStyle, NamedType,
@@ -11,9 +11,11 @@ use quote::*;
 use syn::Ident;
 
 pub fn quote_struct(export: &NamedType, schema: StructLike<'_>, types: &TypeMap) -> TokenStream {
-    if export.binding_style == BindingStyle::Handle {
-        return class::quote_handle_type(export);
-    }
+    assert!(
+        matches!(export.binding_style, BindingStyle::Value(..)),
+        "Trying to generate by-value marshaling for {} which is expected to be marshaled by handle",
+        export.name,
+    );
 
     let ident = format_ident!("{}", &*export.name);
     let raw_ident = binding::raw_ident(&export.name);

--- a/cs-bindgen-macro/src/handle.rs
+++ b/cs-bindgen-macro/src/handle.rs
@@ -1,6 +1,6 @@
 //! Utilities for generating the bindings for types that should be marshaled as a handle.
 
-use crate::{describe_named_type, repr_impl, BindingStyle};
+use crate::{describe_named_type, impl_named, repr_impl, BindingStyle};
 use proc_macro2::TokenStream;
 use quote::*;
 use syn::*;
@@ -9,6 +9,7 @@ pub fn quote_type_as_handle(ident: &Ident) -> syn::Result<TokenStream> {
     let drop_ident = format_drop_ident!(ident);
     let describe_fn = describe_named_type(ident, BindingStyle::Handle);
     let repr_fn = repr_impl(ident);
+    let named_impl = impl_named(ident);
 
     Ok(quote! {
         // Implement `Abi` for the type and references to the type.
@@ -73,6 +74,9 @@ pub fn quote_type_as_handle(ident: &Ident) -> syn::Result<TokenStream> {
 
         // Export a function that describes the exported type.
         #describe_fn
+
+        // Implement the `Named` trait for the type.
+        #named_impl
 
         // Export a function that can be used for dropping an instance of the type.
         #[no_mangle]

--- a/cs-bindgen-macro/src/handle.rs
+++ b/cs-bindgen-macro/src/handle.rs
@@ -1,6 +1,6 @@
 //! Utilities for generating the bindings for types that should be marshaled as a handle.
 
-use crate::{describe_named_type, BindingStyle};
+use crate::{describe_named_type, repr_impl, BindingStyle};
 use proc_macro2::TokenStream;
 use quote::*;
 use syn::*;
@@ -8,12 +8,15 @@ use syn::*;
 pub fn quote_type_as_handle(ident: &Ident) -> syn::Result<TokenStream> {
     let drop_ident = format_drop_ident!(ident);
     let describe_fn = describe_named_type(ident, BindingStyle::Handle);
+    let repr_fn = repr_impl(ident);
 
     Ok(quote! {
         // Implement `Abi` for the type and references to the type.
 
         impl cs_bindgen::abi::Abi for #ident {
             type Abi = *const Self;
+
+            #repr_fn
 
             fn as_abi(&self) -> Self::Abi {
                 self
@@ -31,6 +34,10 @@ pub fn quote_type_as_handle(ident: &Ident) -> syn::Result<TokenStream> {
         impl<'a> cs_bindgen::abi::Abi for &'a #ident {
             type Abi = *const #ident;
 
+            fn repr() -> cs_bindgen::shared::Repr {
+                cs_bindgen::shared::Repr::Ref(Box::new(#ident::repr()))
+            }
+
             fn as_abi(&self) -> Self::Abi {
                 #ident::as_abi(self)
             }
@@ -46,6 +53,10 @@ pub fn quote_type_as_handle(ident: &Ident) -> syn::Result<TokenStream> {
 
         impl<'a> cs_bindgen::abi::Abi for &'a mut #ident {
             type Abi = *const #ident;
+
+            fn repr() -> cs_bindgen::shared::Repr {
+                cs_bindgen::shared::Repr::Ref(Box::new(#ident::repr()))
+            }
 
             fn as_abi(&self) -> Self::Abi {
                 #ident::as_abi(self)

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -101,7 +101,7 @@ fn quote_fn_item(item: ItemFn) -> syn::Result<TokenStream> {
     let describe_output = match &signature.output {
         ReturnType::Default => quote! { None },
         ReturnType::Type(_, return_type) => quote! {
-            Some(describe::<#return_type>().expect("Failed to generate schema for return type"))
+            Some(<#return_type as cs_bindgen::abi::Abi>::repr())
         },
     };
 
@@ -136,7 +136,7 @@ fn quote_fn_item(item: ItemFn) -> syn::Result<TokenStream> {
     let describe_args = inputs.iter().map(|(ident, ty)| {
         let name = ident.to_string();
         quote! {
-            (#name.into(), describe::<#ty>().expect("Failed to generate schema for argument type"))
+            cs_bindgen::shared::FnArg::new(#name, <#ty as cs_bindgen::abi::Abi>::repr())
         }
     });
 

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -351,7 +351,7 @@ fn quote_method_item(item: ImplItemMethod, self_ty: &Type) -> syn::Result<TokenS
             let export = Method {
                 name: #name.into(),
                 binding: #binding_name.into(),
-                self_type: describe::<#self_ty>().expect("Failed to generate schema for self type"),
+                self_type: <#self_ty as cs_bindgen::abi::NamedType>::TYPE_NAME.clone(),
                 receiver: #describe_receiver,
                 inputs: vec![#(
                     #describe_args,
@@ -457,6 +457,17 @@ fn describe_named_type(ident: &Ident, style: BindingStyle) -> TokenStream {
             };
 
             std::boxed::Box::new(cs_bindgen::shared::serialize_export(export).into())
+        }
+    }
+}
+
+fn impl_type_name(ident: &Ident) -> TokenStream {
+    quote! {
+        impl cs_bindgen::abi::NamedType for #ident {
+            const TYPE_NAME: cs_bindgen::shared::TypeName = cs_bindgen::shared::TypeName {
+                name: std::borrow::Cow::Borrowed(stringify!(#ident)),
+                module: std::borrow::Cow::Borrowed(module_path!()),
+            };
         }
     }
 }

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -305,7 +305,7 @@ fn quote_method_item(item: ImplItemMethod, self_ty: &Type) -> syn::Result<TokenS
     let describe_output = match &signature.output {
         ReturnType::Default => quote! { None },
         ReturnType::Type(_, return_type) => quote! {
-            Some(describe::<#return_type>().expect("Failed to generate schema for return type"))
+            Some(<#return_type as cs_bindgen::abi::Abi>::repr())
         },
     };
 
@@ -339,7 +339,7 @@ fn quote_method_item(item: ImplItemMethod, self_ty: &Type) -> syn::Result<TokenS
     let describe_args = inputs.iter().map(|(ident, ty)| {
         let name = ident.to_string();
         quote! {
-            (#name.into(), describe::<#ty>().expect("Failed to generate schema for argument type"))
+            cs_bindgen::shared::FnArg::new(#name, <#ty as cs_bindgen::abi::Abi>::repr())
         }
     });
 
@@ -351,7 +351,7 @@ fn quote_method_item(item: ImplItemMethod, self_ty: &Type) -> syn::Result<TokenS
             let export = Method {
                 name: #name.into(),
                 binding: #binding_name.into(),
-                self_type: <#self_ty as cs_bindgen::abi::NamedType>::type_name(),
+                self_type: <#self_ty as cs_bindgen::shared::Named>::type_name(),
                 receiver: #describe_receiver,
                 inputs: vec![#(
                     #describe_args,

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -1,6 +1,6 @@
 use crate::{
-    describe_named_type, handle, has_derive_copy, quote_index_fn, quote_vec_drop_fn,
-    reject_generics, repr_impl, type_name_expr, value, BindingStyle,
+    describe_named_type, handle, has_derive_copy, impl_named, quote_index_fn, quote_vec_drop_fn,
+    reject_generics, repr_impl, value, BindingStyle,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
@@ -17,6 +17,7 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
 
     // Determine whether we should marshal the type as a handle or by value.
     if has_derive_copy(&item.attrs)? {
+        let named_impl = impl_named(&item.ident);
         let describe_impl = describe_struct(&item);
 
         fn field_accessor(index: usize, field: &Field) -> TokenStream {
@@ -78,6 +79,7 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
                 }
             }
 
+            #named_impl
             #describe_impl
             #describe_fn
             #index_fn
@@ -145,12 +147,10 @@ fn describe_struct(item: &ItemStruct) -> TokenStream {
         }
     };
 
-    let type_name = type_name_expr(ident);
-
     quote! {
         impl cs_bindgen::shared::schematic::Describe for #ident {
             fn type_name() -> cs_bindgen::shared::TypeName {
-                #type_name
+                <Self as cs_bindgen::shared::Named>::type_name()
             }
 
             fn describe<D>(describer: D) -> Result<D::Ok, D::Error>
@@ -159,7 +159,7 @@ fn describe_struct(item: &ItemStruct) -> TokenStream {
             {
                 use cs_bindgen::shared::schematic::{Describer, DescribeStruct, DescribeTupleStruct};
 
-                let type_name = cs_bindgen::shared::schematic::type_name!(#ident);
+                let type_name = <Self as cs_bindgen::shared::Named>::type_name();
                 #body
             }
         }

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -83,7 +83,6 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
         let binding = handle::quote_type_as_handle(&item.ident)?;
         Ok(quote! {
             #binding
-            #describe_impl
         })
     }
 }

--- a/cs-bindgen-shared/Cargo.toml
+++ b/cs-bindgen-shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.99.2"
-schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "6decc4f" }
+schematic = { version = "0.1.0", git = "https://github.com/randomPoison/schematic", rev = "ef03b33" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -142,14 +142,7 @@ pub enum Repr {
     F32,
     F64,
 
-    /// A user defined type passed by handle.
-    ///
-    /// The referenced type must be included in the set of exported types, such that the
-    /// given `TypeName` can be used to look up the full schema and metadata for the
-    /// type.
-    Handle(TypeName),
-
-    /// A user defined type passed by value.
+    /// A user defined type.
     ///
     /// The referenced type must be included in the set of exported types, such that the
     /// given `TypeName` can be used to look up the full schema and metadata for the

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -182,3 +182,20 @@ pub enum Repr {
         err: Box<Repr>,
     },
 }
+
+impl Repr {
+    /// Gets the repr for some user-defined type `T`.
+    ///
+    /// Returns [`Repr::Named`] with the [`TypeName`] returned by `T`'s
+    /// [`Named::type_name`] impl.
+    pub fn named<T: Named>() -> Self {
+        Repr::Named(T::type_name())
+    }
+}
+
+/// A user-defined type.
+pub trait Named {
+    // TODO: Make this an associated constant once we stop using schematic and our
+    // custom `TypeName` type doesn't require allocation.
+    fn type_name() -> TypeName;
+}

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -46,7 +46,7 @@ pub struct Func {
     ///
     /// Note that this is the return type of the original function, NOT the generated
     /// binding function.
-    pub output: Option<Schema>,
+    pub output: Option<Repr>,
 }
 
 /// A user-defined type (i.e. a struct or an enum).
@@ -82,13 +82,25 @@ pub struct Method {
     pub self_type: TypeName,
     pub receiver: Option<ReceiverStyle>,
     pub inputs: Vec<FnArg>,
-    pub output: Option<Schema>,
+    pub output: Option<Repr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FnArg {
     pub name: Cow<'static, str>,
-    pub ty: Repr,
+    pub repr: Repr,
+}
+
+impl FnArg {
+    pub fn new<N>(name: N, repr: Repr) -> Self
+    where
+        N: Into<Cow<'static, str>>,
+    {
+        Self {
+            name: name.into(),
+            repr,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/cs-bindgen/src/abi.rs
+++ b/cs-bindgen/src/abi.rs
@@ -16,8 +16,7 @@
 //! [nomicon-interop]: https://doc.rust-lang.org/nomicon/ffi.html#interoperability-with-foreign-code
 
 use core::mem::MaybeUninit;
-use cs_bindgen_shared::{schematic, Repr, TypeName};
-use schematic::Describe;
+use cs_bindgen_shared::Repr;
 use std::{convert::TryInto, mem, slice, str};
 
 /// The ABI-compatible equivalent to [`String`].
@@ -29,21 +28,6 @@ pub type RawString = RawVec<u8>;
 ///
 /// [`&str`]: https://doc.rust-lang.org/std/primitive.str.html
 pub type RawStr = RawSlice<u8>;
-
-/// Helper trait for accessing the type name for exported types.
-///
-/// Not all types implementing `Abi` need to implement `Describe`, but all types
-/// need to be able to referenced by name. This trait provides a uniform way to
-/// access a type's name when generating a reference to a type.
-pub trait NamedType {
-    fn type_name() -> TypeName;
-}
-
-impl<T: Describe> NamedType for T {
-    fn type_name() -> TypeName {
-        <T as Describe>::type_name()
-    }
-}
 
 /// A value that is ABI-compatible with C#.
 ///

--- a/cs-bindgen/tests/manual_derive.rs
+++ b/cs-bindgen/tests/manual_derive.rs
@@ -48,11 +48,17 @@ pub struct ExampleStruct {
     pub field: String,
 }
 
+impl Named for ExampleStruct {
+    fn type_name() -> TypeName {
+        TypeName::new("ExampleStruct", module_path!())
+    }
+}
+
 impl Abi for ExampleStruct {
     type Abi = *const Self;
 
     fn repr() -> Repr {
-        Repr::Handle(TypeName::new("ExampleStruct", module_path!()))
+        Repr::named::<Self>()
     }
 
     fn as_abi(&self) -> Self::Abi {

--- a/cs-bindgen/tests/opaque_handle_type.rs
+++ b/cs-bindgen/tests/opaque_handle_type.rs
@@ -1,0 +1,12 @@
+//! Verify that handle types can contain types that aren't exported. Handle types
+//! are meant to be opaque, so their contents shouldn't impact their ability to be
+//! exported to C#.
+
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+pub struct HandleType {
+    pub non_exported_type: NonExportedType,
+}
+
+pub struct NonExportedType;

--- a/cs-bindgen/tests/simple_enum_derive.rs
+++ b/cs-bindgen/tests/simple_enum_derive.rs
@@ -18,7 +18,7 @@ use strum::{EnumIter, IntoEnumIterator};
 fn simple_enum_round_trip() {
     #[cs_bindgen]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
-    enum Simple {
+    pub enum Simple {
         Zero,
         One,
         Two,
@@ -65,7 +65,7 @@ fn simple_enum_explicit_discriminants() {
 fn simple_enum_explicit_first_discriminant() {
     #[cs_bindgen]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
-    enum FirstDiscriminant {
+    pub enum FirstDiscriminant {
         Zero = 123,
         One,
         Two,

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -47,16 +47,6 @@ namespace TestRunner
             Assert.Equal(expected, actual);
         }
 
-        // TODO: Re-enable test case once we fix support for passing list of handle types.
-        // [Fact]
-        // public void ReturnHandleList()
-        // {
-        //     var items = IntegrationTests.ReturnHandleVec();
-        //     Assert.Equal(2, items.Count);
-        //     Assert.Equal(33, items[0].Bar());
-        //     Assert.Equal(12345, items[1].Bar());
-        // }
-
         [Fact]
         public void ReturnStructList()
         {

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -62,23 +62,6 @@ pub fn return_vec_bool() -> Vec<bool> {
 }
 
 #[cs_bindgen]
-pub struct HandleStruct {
-    pub bar: i32,
-}
-
-#[cs_bindgen]
-pub fn return_handle_vec() -> Vec<HandleStruct> {
-    vec![HandleStruct { bar: 33 }, HandleStruct { bar: 12345 }]
-}
-
-#[cs_bindgen]
-impl HandleStruct {
-    pub fn bar(&self) -> i32 {
-        self.bar
-    }
-}
-
-#[cs_bindgen]
 #[derive(Debug, Clone, Copy)]
 pub struct CopyStruct {
     pub bar: i32,


### PR DESCRIPTION
Closes #57 

This PR reworks how we describe types such that we don't need handle types to implement `Describe`. In doing so, it makes substantial changes to how we describe exported types. The main change is that we now have our own `Repr` enum and have replaced most usages of `schematic::Schema` with `Repr`. At this point `Schema` is only used to describe by-value types, which can reasonably be expected to only contain types that also implement `Describe`.

This is the first step towards fully removing the dependency on schematic (tracked in #59).