### PR TITLE
Support passing list types to Rust

### DIFF
--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -176,6 +176,76 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
 
         [DllImport(
             #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_u8(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_i8(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_u16(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_i16(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_u32(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_i32(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_u64(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_i64(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_usize(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_isize(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_f32(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_f64(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_bool(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern RawVec __cs_bindgen_convert_vec_char(RawSlice raw);
+
+        [DllImport(
+            #dll_name,
             EntryPoint = "__cs_bindgen_string_from_utf16",
             CallingConvention = CallingConvention.Cdecl)]
         internal static extern RawVec __cs_bindgen_string_from_utf16(RawSlice raw);
@@ -260,7 +330,7 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
         internal static void __FromRaw(RawVec raw, out List<double> result)
         {
             result = raw.ToPrimitiveList<double>();
-            __bindings.__cs_bindgen_drop_vec_f32(raw);
+            __bindings.__cs_bindgen_drop_vec_f64(raw);
         }
 
         internal static void __FromRaw(RawVec raw, out List<bool> result)
@@ -292,6 +362,64 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
             {
                 result = __cs_bindgen_string_from_utf16(new RawSlice((IntPtr)charPtr, value.Length));
             }
+        }
+
+        internal static void __IntoRaw(List<byte> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_u8);
+        }
+
+        internal static void __IntoRaw(List<sbyte> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_i8);
+        }
+
+        internal static void __IntoRaw(List<short> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_i16);
+        }
+
+        internal static void __IntoRaw(List<ushort> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_u16);
+        }
+
+        internal static void __IntoRaw(List<int> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_i32);
+        }
+
+        internal static void __IntoRaw(List<uint> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_u32);
+        }
+
+        internal static void __IntoRaw(List<long> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_i64);
+        }
+
+        internal static void __IntoRaw(List<ulong> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_u64);
+        }
+
+        internal static void __IntoRaw(List<float> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_f32);
+        }
+
+        internal static void __IntoRaw(List<double> value, out RawVec result)
+        {
+            result = RawVec.FromPrimitiveList(value, __cs_bindgen_convert_vec_f64);
+        }
+
+        internal static void __IntoRaw(List<bool> value, out RawVec result)
+        {
+            result = RawVec.FromList<bool, byte>(
+                value,
+                item => item ? (byte)1 : (byte)0,
+                __cs_bindgen_convert_vec_bool);
         }
     });
 
@@ -362,6 +490,20 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 }
 
                 return result;
+            }
+
+            public static RawVec FromPrimitiveList<T>(List<T> items, Func<RawSlice, RawVec> allocVec)
+                where T: unmanaged
+            {
+                // TODO: It would be nice to not have to copy the list in order to get the pointer.
+                // Support for getting a `Span<T>` from a `List<T>` is supposedly coming in
+                // netstandard5.0, though even then we wouldn't be able to use it in Unity for a
+                // while.
+                var array = items.ToArray();
+                fixed (T* ptr = array)
+                {
+                    return allocVec(new RawSlice((IntPtr)ptr, items.Count));
+                }
             }
 
             public static RawVec FromList<T, R>(List<T> items, Func<T, R> convertElement, Func<RawSlice, RawVec> handleResult)

--- a/cs-bindgen-cli/src/generate.rs
+++ b/cs-bindgen-cli/src/generate.rs
@@ -364,6 +364,37 @@ pub fn generate_bindings(exports: Vec<Export>, opt: &Opt) -> Result<String, fail
                 return result;
             }
 
+            public static RawVec FromList<T, R>(List<T> items, Func<T, R> convertElement, Func<RawSlice, RawVec> handleResult)
+                where R : unmanaged
+            {
+                if (items.Count <= 32)
+                {
+                    Span<R> rawItems = stackalloc R[items.Count];
+                    for (int index = 0; index < items.Count; index += 1)
+                    {
+                        rawItems[index] = convertElement(items[index]);
+                    }
+
+                    fixed (R* ptr = rawItems)
+                    {
+                        return handleResult(new RawSlice((IntPtr)ptr, items.Count));
+                    }
+                }
+                else
+                {
+                    var rawItems = new R[items.Count];
+                    for (int index = 0; index < items.Count; index += 1)
+                    {
+                        rawItems[index] = convertElement(items[index]);
+                    }
+
+                    fixed (R* ptr = rawItems)
+                    {
+                        return handleResult(new RawSlice((IntPtr)ptr, items.Count));
+                    }
+                }
+            }
+
             public RawSlice AsSlice()
             {
                 return new RawSlice(Ptr, Length);

--- a/cs-bindgen-macro/src/enumeration.rs
+++ b/cs-bindgen-macro/src/enumeration.rs
@@ -1,6 +1,6 @@
 use crate::{
-    describe_named_type, impl_named, quote_index_fn, quote_vec_drop_fn, reject_generics, repr_impl,
-    value, BindingStyle,
+    describe_named_type, impl_named, quote_convert_list_fn, quote_index_fn, quote_vec_drop_fn,
+    reject_generics, repr_impl, value, BindingStyle,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
@@ -111,6 +111,7 @@ fn quote_simple_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
 
     let repr_fn = repr_impl(&ident);
     let index_fn = quote_index_fn(&ident);
+    let convert_list_fn = quote_convert_list_fn(&ident);
     let drop_vec_fn = quote_vec_drop_fn(&ident);
 
     Ok(quote! {
@@ -151,6 +152,7 @@ fn quote_simple_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
         }
 
         #index_fn
+        #convert_list_fn
         #drop_vec_fn
     })
 }
@@ -299,6 +301,7 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
 
     let repr_fn = repr_impl(ident);
     let index_fn = quote_index_fn(ident);
+    let convert_list_fn = quote_convert_list_fn(ident);
     let vec_drop_fn = quote_vec_drop_fn(ident);
 
     Ok(quote! {
@@ -341,6 +344,7 @@ fn quote_complex_enum(item: &ItemEnum) -> syn::Result<TokenStream> {
         }
 
         #index_fn
+        #convert_list_fn
         #vec_drop_fn
     })
 }

--- a/cs-bindgen-macro/src/strukt.rs
+++ b/cs-bindgen-macro/src/strukt.rs
@@ -1,6 +1,6 @@
 use crate::{
-    describe_named_type, handle, has_derive_copy, impl_named, quote_index_fn, quote_vec_drop_fn,
-    reject_generics, repr_impl, value, BindingStyle,
+    describe_named_type, handle, has_derive_copy, impl_named, quote_convert_list_fn,
+    quote_index_fn, quote_vec_drop_fn, reject_generics, repr_impl, value, BindingStyle,
 };
 use proc_macro2::{Literal, TokenStream};
 use quote::*;
@@ -32,6 +32,7 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
         let abi_struct = value::quote_abi_struct(&abi_struct_ident, &item.fields);
         let describe_fn = describe_named_type(&item.ident, BindingStyle::Value);
         let index_fn = quote_index_fn(&item.ident);
+        let convert_list_fn = quote_convert_list_fn(&item.ident);
         let vec_drop_fn = quote_vec_drop_fn(&item.ident);
 
         let into_abi_fields = value::into_abi_fields(&item.fields, |index, field| {
@@ -83,6 +84,7 @@ pub fn quote_struct_item(item: ItemStruct) -> syn::Result<TokenStream> {
             #describe_impl
             #describe_fn
             #index_fn
+            #convert_list_fn
             #vec_drop_fn
         })
     } else {

--- a/cs-bindgen-shared/src/lib.rs
+++ b/cs-bindgen-shared/src/lib.rs
@@ -64,6 +64,7 @@ pub struct NamedType {
 
     pub index_fn: Cow<'static, str>,
     pub drop_vec_fn: Cow<'static, str>,
+    pub convert_list_fn: Cow<'static, str>,
 }
 
 impl NamedType {

--- a/cs-bindgen/src/abi.rs
+++ b/cs-bindgen/src/abi.rs
@@ -464,6 +464,15 @@ impl<'a> From<&'a str> for RawSlice<u8> {
     }
 }
 
+/// Converts a slice of `T::Abi` to a vec of `T`, converting each element.
+pub unsafe fn convert_list<T: Abi>(raw: RawSlice<T::Abi>) -> RawVec<T> {
+    raw.as_slice()
+        .iter()
+        .map(|&raw| T::from_abi(raw))
+        .collect::<Vec<_>>()
+        .into()
+}
+
 /// Generates the `Abi` implementation for arrays of different lengths.
 ///
 /// For an array of type `T`, it's ABI-compatible representation is an array of the

--- a/cs-bindgen/src/exports.rs
+++ b/cs-bindgen/src/exports.rs
@@ -14,36 +14,40 @@
 //!
 //! [`export`]: ../macro.export.html
 
-use crate::abi::{RawSlice, RawString, RawVec};
+use crate::abi::{self, Abi, RawSlice, RawString, RawVec};
 
 macro_rules! drop_vec {
-    ( $( $prim:ty => $fn_name:ident, )* ) => {
+    ( $( $prim:ty => [$drop_fn:ident, $convert_fn:ident], )* ) => {
         $(
-            pub unsafe fn $fn_name(raw: RawVec<$prim>) {
+            pub unsafe fn $drop_fn(raw: RawVec<$prim>) {
                 let _ = raw.into_vec();
+            }
+
+            pub unsafe fn $convert_fn(raw: RawSlice<<$prim as Abi>::Abi>) -> RawVec<$prim> {
+                abi::convert_list(raw)
             }
         )*
     }
 }
 
 drop_vec! {
-    u8 => __cs_bindgen_drop_vec_u8,
-    u16 => __cs_bindgen_drop_vec_u16,
-    u32 => __cs_bindgen_drop_vec_u32,
-    u64 => __cs_bindgen_drop_vec_u64,
-    usize => __cs_bindgen_drop_vec_usize,
+    u8 => [__cs_bindgen_drop_vec_u8, __cs_bindgen_convert_vec_u8],
+    u16 => [__cs_bindgen_drop_vec_u16, __cs_bindgen_convert_vec_u16],
+    u32 => [__cs_bindgen_drop_vec_u32, __cs_bindgen_convert_vec_u32],
+    u64 => [__cs_bindgen_drop_vec_u64, __cs_bindgen_convert_vec_u64],
+    usize => [__cs_bindgen_drop_vec_usize, __cs_bindgen_convert_vec_usize],
 
-    i8 => __cs_bindgen_drop_vec_i8,
-    i16 => __cs_bindgen_drop_vec_i16,
-    i32 => __cs_bindgen_drop_vec_i32,
-    i64 => __cs_bindgen_drop_vec_i64,
-    isize => __cs_bindgen_drop_vec_isize,
+    i8 => [__cs_bindgen_drop_vec_i8, __cs_bindgen_convert_vec_i8],
+    i16 => [__cs_bindgen_drop_vec_i16, __cs_bindgen_convert_vec_i16],
+    i32 => [__cs_bindgen_drop_vec_i32, __cs_bindgen_convert_vec_i32],
+    i64 => [__cs_bindgen_drop_vec_i64, __cs_bindgen_convert_vec_i64],
+    isize => [__cs_bindgen_drop_vec_isize, __cs_bindgen_convert_vec_isize],
 
-    f32 => __cs_bindgen_drop_vec_f32,
-    f64 => __cs_bindgen_drop_vec_f64,
+    f32 => [__cs_bindgen_drop_vec_f32, __cs_bindgen_convert_vec_f32],
+    f64 => [__cs_bindgen_drop_vec_f64, __cs_bindgen_convert_vec_f64],
 
-    bool => __cs_bindgen_drop_vec_bool,
-    char => __cs_bindgen_drop_vec_char,
+    bool => [__cs_bindgen_drop_vec_bool, __cs_bindgen_convert_vec_bool],
+    char => [__cs_bindgen_drop_vec_char, __cs_bindgen_convert_vec_char],
 }
 
 /// Converts a C# string (i.e. a UTF-16 slice) into a Rust string.

--- a/cs-bindgen/src/lib.rs
+++ b/cs-bindgen/src/lib.rs
@@ -38,17 +38,29 @@ macro_rules! export {
         $crate::export!(fn __cs_bindgen_drop_vec_u32(raw: $crate::abi::RawVec<u32>));
         $crate::export!(fn __cs_bindgen_drop_vec_u64(raw: $crate::abi::RawVec<u64>));
         $crate::export!(fn __cs_bindgen_drop_vec_usize(raw: $crate::abi::RawVec<usize>));
-
         $crate::export!(fn __cs_bindgen_drop_vec_i8(raw: $crate::abi::RawVec<i8>));
         $crate::export!(fn __cs_bindgen_drop_vec_i16(raw: $crate::abi::RawVec<i16>));
         $crate::export!(fn __cs_bindgen_drop_vec_i32(raw: $crate::abi::RawVec<i32>));
         $crate::export!(fn __cs_bindgen_drop_vec_i64(raw: $crate::abi::RawVec<i64>));
         $crate::export!(fn __cs_bindgen_drop_vec_isize(raw: $crate::abi::RawVec<isize>));
-
         $crate::export!(fn __cs_bindgen_drop_vec_f32(raw: $crate::abi::RawVec<f32>));
         $crate::export!(fn __cs_bindgen_drop_vec_f64(raw: $crate::abi::RawVec<f64>));
-
         $crate::export!(fn __cs_bindgen_drop_vec_bool(raw: $crate::abi::RawVec<bool>));
         $crate::export!(fn __cs_bindgen_drop_vec_char(raw: $crate::abi::RawVec<char>));
+
+        $crate::export!(fn __cs_bindgen_convert_vec_u8(raw: $crate::abi::RawSlice<<u8 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<u8>);
+        $crate::export!(fn __cs_bindgen_convert_vec_u16(raw: $crate::abi::RawSlice<<u16 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<u16>);
+        $crate::export!(fn __cs_bindgen_convert_vec_u32(raw: $crate::abi::RawSlice<<u32 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<u32>);
+        $crate::export!(fn __cs_bindgen_convert_vec_u64(raw: $crate::abi::RawSlice<<u64 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<u64>);
+        $crate::export!(fn __cs_bindgen_convert_vec_usize(raw: $crate::abi::RawSlice<<usize as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<usize>);
+        $crate::export!(fn __cs_bindgen_convert_vec_i8(raw: $crate::abi::RawSlice<<i8 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<i8>);
+        $crate::export!(fn __cs_bindgen_convert_vec_i16(raw: $crate::abi::RawSlice<<i16 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<i16>);
+        $crate::export!(fn __cs_bindgen_convert_vec_i32(raw: $crate::abi::RawSlice<<i32 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<i32>);
+        $crate::export!(fn __cs_bindgen_convert_vec_i64(raw: $crate::abi::RawSlice<<i64 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<i64>);
+        $crate::export!(fn __cs_bindgen_convert_vec_isize(raw: $crate::abi::RawSlice<<isize as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<isize>);
+        $crate::export!(fn __cs_bindgen_convert_vec_f32(raw: $crate::abi::RawSlice<<f32 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<f32>);
+        $crate::export!(fn __cs_bindgen_convert_vec_f64(raw: $crate::abi::RawSlice<<f64 as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<f64>);
+        $crate::export!(fn __cs_bindgen_convert_vec_bool(raw: $crate::abi::RawSlice<<bool as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<bool>);
+        $crate::export!(fn __cs_bindgen_convert_vec_char(raw: $crate::abi::RawSlice<<char as $crate::abi::Abi>::Abi>) -> $crate::abi::RawVec<char>);
     };
 }

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -50,10 +50,15 @@ namespace TestRunner
         [Fact]
         public void ReturnStructList()
         {
-            var items = IntegrationTests.ReturnStructVec();
-            Assert.Equal(2, items.Count);
-            Assert.Equal(33, items[0].Bar);
-            Assert.Equal(12345, items[1].Bar);
+            var expected = new List<CopyStruct>() {
+                new CopyStruct(33),
+                new CopyStruct(12345),
+            };
+            var actual = IntegrationTests.StructVecRoundTrip(expected);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.Equal(expected[0].Bar, actual[0].Bar);
+            Assert.Equal(expected[1].Bar, actual[1].Bar);
         }
 
         [Fact]

--- a/integration-tests/TestRunner/Collections.cs
+++ b/integration-tests/TestRunner/Collections.cs
@@ -65,7 +65,7 @@ namespace TestRunner
         public void ReturnSimpleEnumList()
         {
             var expected = new List<SimpleCEnum>() { SimpleCEnum.Foo, SimpleCEnum.Bar, SimpleCEnum.Baz };
-            var actual = IntegrationTests.ReturnSimpleEnumVec();
+            var actual = IntegrationTests.RoundTripSimpleEnumVec(expected);
             Assert.Equal(expected, actual);
         }
 
@@ -87,7 +87,7 @@ namespace TestRunner
                 new DataEnum.Bar("Cool string"),
                 new DataEnum.Coolness(new InnerEnum.Coolest(SimpleCEnum.Foo)),
             };
-            var actual = IntegrationTests.ReturnDataEnumVec();
+            var actual = IntegrationTests.RoundTripDataEnumVec(expected);
             Assert.Equal(expected, actual);
         }
 

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -1,9 +1,6 @@
 //! Tests verifying that collection types (e.g. arrays and maps) can be used with C#.
 
-use crate::{
-    data_enum::{DataEnum, InnerEnum},
-    simple_enum::SimpleCEnum,
-};
+use crate::{data_enum::DataEnum, simple_enum::SimpleCEnum};
 use cs_bindgen::prelude::*;
 
 #[cs_bindgen]
@@ -73,17 +70,13 @@ pub fn struct_vec_round_trip(val: Vec<CopyStruct>) -> Vec<CopyStruct> {
 }
 
 #[cs_bindgen]
-pub fn return_simple_enum_vec() -> Vec<SimpleCEnum> {
-    vec![SimpleCEnum::Foo, SimpleCEnum::Bar, SimpleCEnum::Baz]
+pub fn round_trip_simple_enum_vec(val: Vec<SimpleCEnum>) -> Vec<SimpleCEnum> {
+    val
 }
 
 #[cs_bindgen]
-pub fn return_data_enum_vec() -> Vec<DataEnum> {
-    vec![
-        DataEnum::Foo,
-        DataEnum::Bar("Cool string".into()),
-        DataEnum::Coolness(InnerEnum::Coolest(SimpleCEnum::Foo)),
-    ]
+pub fn round_trip_data_enum_vec(val: Vec<DataEnum>) -> Vec<DataEnum> {
+    val
 }
 
 #[cs_bindgen]

--- a/integration-tests/src/collections.rs
+++ b/integration-tests/src/collections.rs
@@ -68,8 +68,8 @@ pub struct CopyStruct {
 }
 
 #[cs_bindgen]
-pub fn return_struct_vec() -> Vec<CopyStruct> {
-    vec![CopyStruct { bar: 33 }, CopyStruct { bar: 12345 }]
+pub fn struct_vec_round_trip(val: Vec<CopyStruct>) -> Vec<CopyStruct> {
+    val
 }
 
 #[cs_bindgen]
@@ -84,4 +84,10 @@ pub fn return_data_enum_vec() -> Vec<DataEnum> {
         DataEnum::Bar("Cool string".into()),
         DataEnum::Coolness(InnerEnum::Coolest(SimpleCEnum::Foo)),
     ]
+}
+
+#[cs_bindgen]
+#[derive(Clone)]
+pub enum ValueTypeWithCollection {
+    Foo { values: Vec<u32> },
 }


### PR DESCRIPTION
This PR implements the conversion logic on the C# side for passing lists of values to Rust functions. Most of the functionality on the Rust side was already in place, the only addition was that we now export functions for taking a `&[T::Abi]` and converting it into a `Vec<T>`. This allows the C# side to "allocate" a Rust `Vec` when one is expected by an exported Rust function (or inside the raw representation of a type being passed to an exported function) while avoiding the tricky questions that arise if we try to pass a `RawVec` that wasn't allocated on the Rust side. The main drawback to this approach is that it means an extra call into Rust for each `Vec` that needs to be created, though we don't yet know how expense the cross-language calls are yet.