### PR TITLE
Setup CI for testing against .NET 2.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,28 +6,28 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest ]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.101'
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "2.0.0"
 
-    - name: Build
-      run: cargo build --verbose
+      - name: Build
+        run: cargo build --verbose
 
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Run tests
+        run: cargo test --verbose
 
-    - name: Build integration tests
-      run: |
-        rustup target add wasm32-unknown-unknown
-        cargo run -p builder
+      - name: Build integration tests
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo run -p builder
 
-    - name: Run integration tests
-      run: |
-        cd integration-tests/TestRunner
-        dotnet test
+      - name: Run integration tests
+        run: |
+          cd integration-tests/TestRunner
+          dotnet test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.1.102"
+          dotnet-version: "2.1.701"
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "2.0.0"
+          dotnet-version: "3.1.102"
 
       - name: Build
         run: cargo build --verbose


### PR DESCRIPTION
Update the CI workflow to use the 2.1 SDK, which supports the particular combination of .NET Core 2.0 and C# 7.3 that we need to test against.