### PR TITLE
Correctly handle long function argument names

### DIFF
--- a/cs-bindgen-cli/src/generate/func.rs
+++ b/cs-bindgen-cli/src/generate/func.rs
@@ -80,7 +80,9 @@ pub fn quote_wrapper_body<'a>(
     output: Option<&TokenStream>,
     types: &TypeMap,
 ) -> TokenStream {
-    let arg_name = args.iter().map(|arg| format_ident!("{}", arg.name));
+    let arg_name = args
+        .iter()
+        .map(|arg| format_ident!("{}", arg.name.to_mixed_case()));
     let temp_arg_name = args.iter().map(|arg| format_ident!("__{}", arg.name));
     let raw_ty = args
         .iter()

--- a/cs-bindgen-macro/src/lib.rs
+++ b/cs-bindgen-macro/src/lib.rs
@@ -118,6 +118,7 @@ fn quote_fn_item(item: ItemFn) -> syn::Result<TokenStream> {
     // Compose the various pieces together into the final binding function.
     let binding = quote! {
         #[no_mangle]
+        #[allow(bad_style)]
         pub unsafe extern "C" fn #binding_ident(
             #( #binding_inputs, )*
         ) #return_decl {
@@ -318,6 +319,7 @@ fn quote_method_item(item: ImplItemMethod, self_ty: &Type) -> syn::Result<TokenS
     // Compose the various pieces together into the final binding function.
     let binding = quote! {
         #[no_mangle]
+        #[allow(bad_style)]
         pub unsafe extern "C" fn #binding_ident(
             #( #binding_inputs, )*
         ) #return_decl {

--- a/integration-tests/src/function.rs
+++ b/integration-tests/src/function.rs
@@ -1,0 +1,38 @@
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+pub fn greet_a_number(num: i32) -> String {
+    format!("Hello, #{}!", num)
+}
+
+#[cs_bindgen]
+pub fn return_a_number() -> i32 {
+    7
+}
+
+#[cs_bindgen]
+pub fn string_arg(arg: String) -> String {
+    format!("Hello, {}!", arg)
+}
+
+#[cs_bindgen]
+pub fn is_seven(value: i32) -> bool {
+    value == 7
+}
+
+#[cs_bindgen]
+pub fn void_return(test: i32) {
+    println!("{}", test);
+}
+
+#[cs_bindgen]
+#[allow(bad_style)]
+pub fn arg_name_test(
+    simple: bool,
+    long_param_name: i32,
+    oddParamName: i32,
+    name_with3OddCasing: i32,
+    _leading_underscore: String,
+) {
+    let _ = (simple, long_param_name, oddParamName, name_with3OddCasing);
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,36 +1,11 @@
-use cs_bindgen::prelude::*;
-
 pub mod collections;
 pub mod copy_types;
 pub mod data_enum;
+pub mod function;
+pub mod method;
 pub mod name_collision;
 pub mod simple_enum;
 pub mod structs;
 
 // Re-export core cs_bindgen functionality. Required in order for the generated Wasm module.
 cs_bindgen::export!();
-
-#[cs_bindgen]
-pub fn greet_a_number(num: i32) -> String {
-    format!("Hello, #{}!", num)
-}
-
-#[cs_bindgen]
-pub fn return_a_number() -> i32 {
-    7
-}
-
-#[cs_bindgen]
-pub fn string_arg(arg: String) -> String {
-    format!("Hello, {}!", arg)
-}
-
-#[cs_bindgen]
-pub fn is_seven(value: i32) -> bool {
-    value == 7
-}
-
-#[cs_bindgen]
-pub fn void_return(test: i32) {
-    println!("{}", test);
-}

--- a/integration-tests/src/method.rs
+++ b/integration-tests/src/method.rs
@@ -1,0 +1,81 @@
+use cs_bindgen::prelude::*;
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct PersonInfo {
+    name: String,
+    age: i32,
+    address: Address,
+}
+
+// Export methods associated with an exported struct. Includes a constructor,
+// getters, setters, and methods that operate on the internal state of the object.
+#[cs_bindgen]
+impl PersonInfo {
+    // TODO: Change the return type back to `Self` once that's supported.
+    pub fn new(name: String, age: i32) -> PersonInfo {
+        Self {
+            name,
+            age,
+            address: Address {
+                street_number: 123,
+                street: "Cool Kids Lane".into(),
+            },
+        }
+    }
+
+    // TODO: Change this to return `&str` once that's supported.
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn age(&self) -> i32 {
+        self.age
+    }
+
+    pub fn set_age(&mut self, age: i32) {
+        self.age = age;
+    }
+
+    pub fn static_function() -> i32 {
+        7
+    }
+
+    pub fn address(&self) -> Address {
+        self.address.clone()
+    }
+
+    pub fn is_minor(&self) -> bool {
+        self.age < 21
+    }
+
+    #[allow(bad_style)]
+    pub fn arg_name_test(
+        simple: bool,
+        long_param_name: i32,
+        oddParamName: i32,
+        name_with3OddCasing: i32,
+        _leading_underscore: String,
+    ) {
+        let _ = (simple, long_param_name, oddParamName, name_with3OddCasing);
+    }
+}
+
+#[cs_bindgen]
+#[derive(Debug, Clone)]
+pub struct Address {
+    street_number: u32,
+    street: String,
+}
+
+#[cs_bindgen]
+impl Address {
+    pub fn street_number(&self) -> u32 {
+        self.street_number
+    }
+
+    // TODO: Change this to return `&str` once that's supported.
+    pub fn street_name(&self) -> String {
+        self.street.clone()
+    }
+}

--- a/integration-tests/src/structs.rs
+++ b/integration-tests/src/structs.rs
@@ -5,71 +5,10 @@ use cs_bindgen::prelude::*;
 // another struct field.
 #[cs_bindgen]
 #[derive(Debug, Clone)]
-pub struct PersonInfo {
-    name: String,
-    age: i32,
-    address: Address,
-}
-
-// Export methods associated with an exported struct. Includes a constructor,
-// getters, setters, and methods that operate on the internal state of the object.
-#[cs_bindgen]
-impl PersonInfo {
-    // TODO: Change the return type back to `Self` once that's supported.
-    pub fn new(name: String, age: i32) -> PersonInfo {
-        Self {
-            name,
-            age,
-            address: Address {
-                street_number: 123,
-                street: "Cool Kids Lane".into(),
-            },
-        }
-    }
-
-    // TODO: Change this to return `&str` once that's supported.
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    pub fn age(&self) -> i32 {
-        self.age
-    }
-
-    pub fn set_age(&mut self, age: i32) {
-        self.age = age;
-    }
-
-    pub fn static_function() -> i32 {
-        7
-    }
-
-    pub fn address(&self) -> Address {
-        self.address.clone()
-    }
-
-    pub fn is_minor(&self) -> bool {
-        self.age < 21
-    }
-}
-
-#[cs_bindgen]
-#[derive(Debug, Clone)]
-pub struct Address {
-    street_number: u32,
-    street: String,
-}
-
-#[cs_bindgen]
-impl Address {
-    pub fn street_number(&self) -> u32 {
-        self.street_number
-    }
-
-    // TODO: Change this to return `&str` once that's supported.
-    pub fn street_name(&self) -> String {
-        self.street.clone()
-    }
+pub struct BasicStruct {
+    pub foo: i32,
+    pub bar: String,
+    pub baz: bool,
 }
 
 // Test a struct with a field that is a data-carrying enum.
@@ -87,14 +26,6 @@ pub struct NewtypeStruct(u32);
 #[cs_bindgen]
 #[derive(Debug, Clone)]
 pub struct TupleStruct(String, String);
-
-// TODO: Support methods on tuple structs.
-// #[cs_bindgen]
-// impl TupleStruct {
-//     pub fn new(first: String, second: String) -> TupleStruct {
-//         Self(first, second)
-//     }
-// }
 
 #[cs_bindgen]
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
This fixes a bug where long function argument names (really any name with at least one `_` word separator in it) would result in invalid code on the C# side. This was because we were converting the argument names to camelCase in the function declaration, but weren't converting them when using them in the function body, resulting in code that referenced variables names that didn't exist.

In fixing this bug I've also reorganized some of the integration test code such that function and method tests are in their own modules.